### PR TITLE
Upgrade Next.js 16 and overhaul SEO tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# Copy to .env.local for local development:
+#   cp .env.example .env.local
+#
+# Set the same keys in Vercel → Project → Settings → Environment Variables
+# (Production + Preview). Never commit real secrets.
+
+# --- Required: Upstash Redis (rate limiting for all /api/* tools) ---
+# Create a Redis DB at https://console.upstash.com → REST API credentials
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
+# --- Recommended: Discord webhook (server-side usage logs) ---
+# Webhook URL looks like:
+#   https://discord.com/api/webhooks/<ID>/<TOKEN>
+# Prefer these server-only names (not NEXT_PUBLIC_*):
+DISCORD_LOGS_ID=
+DISCORD_LOGS_TOKEN=
+
+# --- Deprecated fallback (do not use for new setups) ---
+# Still read by the server if DISCORD_LOGS_* are missing.
+# Remove from Vercel after migrating so secrets are never client-exposed.
+# NEXT_PUBLIC_DISCORD_LOGS_ID=
+# NEXT_PUBLIC_DISCORD_LOGS_TOKEN=
+
+# --- Not required ---
+# Ahrefs Domain Rating uses the free public endpoint (no API key).
+# NODE_ENV is set automatically by Next.js / Vercel.

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# pnpm local store
+.pnpm-store/

--- a/README.md
+++ b/README.md
@@ -22,8 +22,23 @@ Easily review your sitemap links and metadata/og stuff easily
 1. Fork and Clone the repo
 2. If you don't have pnpm run `npm install -g pnpm`
 3. run `pnpm install`
-4. run `pnpm run dev`
-5. Create, a new Branch, make code change make a PR (Contributions are welcome)
-6. HAPPY CODING!
+4. Copy env template: `cp .env.example .env.local` and fill in values (see below)
+5. run `pnpm run dev`
+6. Create a new branch, make code changes, open a PR (contributions welcome)
+
+## Environment variables
+
+See [`.env.example`](.env.example). Required for production/preview on Vercel:
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `UPSTASH_REDIS_REST_URL` | Yes | Rate limiting (`/api/v1`, `/api/sitemap`, `/api/audit`, `/api/domain-rating`) |
+| `UPSTASH_REDIS_REST_TOKEN` | Yes | Rate limiting |
+| `DISCORD_LOGS_ID` | Recommended | Discord webhook ID (server-only usage logs) |
+| `DISCORD_LOGS_TOKEN` | Recommended | Discord webhook token |
+
+Optional / deprecated: `NEXT_PUBLIC_DISCORD_LOGS_*` — server fallback only; remove after migrating to `DISCORD_LOGS_*`.
+
+Ahrefs Domain Rating needs **no** API key (public free endpoint).
 
 ---

--- a/app/(tools)/audit/audit-client.tsx
+++ b/app/(tools)/audit/audit-client.tsx
@@ -6,7 +6,6 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { FadeIn } from "@/components/motion"
 import { AHREFS_DR_ATTRIBUTION } from "@/lib/ahrefs-dr"
 import type { AuditCheck, AuditReport, CheckStatus } from "@/lib/audit/types"
-import { logToolUsage } from "@/lib/log-tool-usage"
 import { cn } from "@/lib/utils"
 import { Check, ChevronDown, Copy, ExternalLink, Loader } from "lucide-react"
 import Link from "next/link"
@@ -114,7 +113,7 @@ export default function AuditClient({ query }: { query: string }) {
   const initial = useMemo(() => initialQuery(query), [query])
   const [value, setValue] = useState(initial)
   const [report, setReport] = useState<AuditReport | null>(null)
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
   const [openCats, setOpenCats] = useState<Record<string, boolean>>({
@@ -135,12 +134,20 @@ export default function AuditClient({ query }: { query: string }) {
     try {
       const res = await fetch(`/api/audit?q=${encodeURIComponent(url.trim())}`)
       const data = await res.json()
+      if (res.status === 429 || data.error === "Rate limit exceeded") {
+        const resetMs = data.reset
+        const hours =
+          typeof resetMs === "number"
+            ? Math.max(1, Math.ceil((resetMs - Date.now()) / 3_600_000))
+            : "?"
+        setError(`Rate limit exceeded. Try again in ${hours} hours.`)
+        return
+      }
       if (!res.ok) {
         setError(data.error || "Audit failed")
         return
       }
       setReport(data as AuditReport)
-      void logToolUsage(url.trim(), "AUDIT")
     } catch {
       setError("Audit failed")
     } finally {
@@ -156,9 +163,13 @@ export default function AuditClient({ query }: { query: string }) {
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    const next = value.trim()
+    const next = value.trim() || DEFAULT_SITE
+    if (next === initial) {
+      void run(next)
+      return
+    }
+    // Navigate only — remount via key={query} runs the audit once.
     router.push(`/audit?q=${encodeURIComponent(next)}`)
-    void run(next)
   }
 
   const copyReport = async () => {
@@ -196,8 +207,11 @@ export default function AuditClient({ query }: { query: string }) {
           className="underline underline-offset-2"
           onClick={() => {
             setValue(DEFAULT_SITE)
+            if (DEFAULT_SITE === initial) {
+              void run(DEFAULT_SITE)
+              return
+            }
             router.push(`/audit?q=${encodeURIComponent(DEFAULT_SITE)}`)
-            void run(DEFAULT_SITE)
           }}
         >
           {DEFAULT_SITE}
@@ -254,6 +268,15 @@ export default function AuditClient({ query }: { query: string }) {
                     className="underline underline-offset-2"
                   >
                     {AHREFS_DR_ATTRIBUTION.text}
+                  </Link>
+                  {" · "}
+                  <Link
+                    href={AHREFS_DR_ATTRIBUTION.license}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline underline-offset-2"
+                  >
+                    License
                   </Link>
                 </p>
               )}

--- a/app/(tools)/audit/audit-client.tsx
+++ b/app/(tools)/audit/audit-client.tsx
@@ -1,0 +1,351 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import { FadeIn } from "@/components/motion"
+import { AHREFS_DR_ATTRIBUTION } from "@/lib/ahrefs-dr"
+import type { AuditCheck, AuditReport, CheckStatus } from "@/lib/audit/types"
+import { logToolUsage } from "@/lib/log-tool-usage"
+import { cn } from "@/lib/utils"
+import { Check, ChevronDown, Copy, ExternalLink, Loader } from "lucide-react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+const DEFAULT_SITE = "https://shrix1.com"
+
+function initialQuery(query: string) {
+  if (!query) return DEFAULT_SITE
+  try {
+    return decodeURIComponent(query)
+  } catch {
+    return query
+  }
+}
+
+function statusColor(status: CheckStatus) {
+  if (status === "pass") return "text-emerald-600 dark:text-emerald-400"
+  if (status === "warn") return "text-amber-600 dark:text-amber-400"
+  return "text-red-600 dark:text-red-400"
+}
+
+function statusDot(status: CheckStatus) {
+  if (status === "pass") return "bg-emerald-500"
+  if (status === "warn") return "bg-amber-500"
+  return "bg-red-500"
+}
+
+function reportToMarkdown(report: AuditReport): string {
+  const lines = [
+    `# SEO Audit — ${report.domain}`,
+    `Score: ${report.score}/100`,
+    `Audited: ${report.auditedAt}`,
+    `URL: ${report.finalUrl}`,
+    typeof report.domainRating === "number"
+      ? `Domain Rating: ${Math.round(report.domainRating)} (${AHREFS_DR_ATTRIBUTION.text})`
+      : null,
+    "",
+    "## Fix first",
+    ...report.fixFirst.map(
+      (c) =>
+        `- [${c.status.toUpperCase()}] ${c.label}: ${c.detail}. Fix: ${c.fixHint}`
+    ),
+    "",
+    ...report.categories.flatMap((cat) => [
+      `## ${cat.label} (${cat.score}/100)`,
+      ...cat.checks.map(
+        (c) =>
+          `- [${c.status.toUpperCase()}] ${c.label}: ${c.value ?? ""} — ${c.detail}`
+      ),
+      "",
+    ]),
+  ]
+  return lines.filter((l) => l !== null).join("\n")
+}
+
+function CheckRow({ check }: { check: AuditCheck }) {
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-start gap-2 py-3 border-b border-border/60 last:border-0">
+      <div className="flex items-start gap-2 min-w-0 flex-1">
+        <span
+          className={cn("mt-1.5 h-2 w-2 rounded-full shrink-0", statusDot(check.status))}
+          aria-hidden
+        />
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+            <span className="font-medium text-sm">{check.label}</span>
+            <span
+              className={cn(
+                "text-xs font-mono uppercase tracking-wide",
+                statusColor(check.status)
+              )}
+            >
+              {check.status}
+            </span>
+          </div>
+          <p className="text-sm text-muted-foreground mt-0.5">{check.detail}</p>
+          {check.value && (
+            <p className="text-xs font-mono mt-1 break-all text-foreground/80">
+              {check.value}
+            </p>
+          )}
+          {check.status !== "pass" && (
+            <p className="text-xs mt-1.5 text-muted-foreground">
+              Fix: {check.fixHint}
+            </p>
+          )}
+        </div>
+      </div>
+      {check.deepLink && (
+        <Link
+          href={check.deepLink}
+          className="text-xs underline underline-offset-2 shrink-0 inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+        >
+          Open tool <ExternalLink className="h-3 w-3" />
+        </Link>
+      )}
+    </div>
+  )
+}
+
+export default function AuditClient({ query }: { query: string }) {
+  const router = useRouter()
+  const initial = useMemo(() => initialQuery(query), [query])
+  const [value, setValue] = useState(initial)
+  const [report, setReport] = useState<AuditReport | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [openCats, setOpenCats] = useState<Record<string, boolean>>({
+    onpage: true,
+    crawl: true,
+    trust: true,
+  })
+  const hasFetched = useRef(false)
+
+  const run = useCallback(async (url: string) => {
+    if (!url.trim()) {
+      setError("Enter a URL")
+      return
+    }
+    setLoading(true)
+    setError(null)
+    setReport(null)
+    try {
+      const res = await fetch(`/api/audit?q=${encodeURIComponent(url.trim())}`)
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error || "Audit failed")
+        return
+      }
+      setReport(data as AuditReport)
+      void logToolUsage(url.trim(), "AUDIT")
+    } catch {
+      setError("Audit failed")
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (hasFetched.current) return
+    hasFetched.current = true
+    void run(initial)
+  }, [initial, run])
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const next = value.trim()
+    router.push(`/audit?q=${encodeURIComponent(next)}`)
+    void run(next)
+  }
+
+  const copyReport = async () => {
+    if (!report) return
+    await navigator.clipboard.writeText(reportToMarkdown(report))
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="w-full max-w-3xl mx-auto mt-8">
+      <form onSubmit={onSubmit} className="flex flex-col sm:flex-row gap-2">
+        <Input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="https://example.com"
+          className="font-mono"
+          aria-label="Site URL to audit"
+        />
+        <Button type="submit" disabled={loading} className="shrink-0">
+          {loading ? (
+            <>
+              <Loader className="h-4 w-4 animate-spin mr-2" />
+              Auditing…
+            </>
+          ) : (
+            "Run free audit"
+          )}
+        </Button>
+      </form>
+      <p className="text-xs text-muted-foreground mt-2 font-mono">
+        Try{" "}
+        <button
+          type="button"
+          className="underline underline-offset-2"
+          onClick={() => {
+            setValue(DEFAULT_SITE)
+            router.push(`/audit?q=${encodeURIComponent(DEFAULT_SITE)}`)
+            void run(DEFAULT_SITE)
+          }}
+        >
+          {DEFAULT_SITE}
+        </button>
+      </p>
+
+      {error && (
+        <p className="mt-6 text-sm text-red-600 dark:text-red-400">{error}</p>
+      )}
+
+      {loading && (
+        <div className="mt-10 space-y-4">
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-40 w-full" />
+          <Skeleton className="h-40 w-full" />
+        </div>
+      )}
+
+      {report && !loading && (
+        <FadeIn className="mt-10 space-y-10">
+          <header className="flex flex-col sm:flex-row sm:items-end justify-between gap-4">
+            <div>
+              <p className="font-mono text-sm text-muted-foreground">
+                {report.domain}
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
+                {new Date(report.auditedAt).toLocaleString()}
+              </p>
+              <div className="mt-4 flex items-baseline gap-3">
+                <span className="text-6xl font-bold font-mono tracking-tight">
+                  {report.score}
+                </span>
+                <span className="text-muted-foreground text-sm">/ 100</span>
+              </div>
+              <div className="mt-3 flex gap-4 text-xs font-mono">
+                <span className="text-red-600 dark:text-red-400">
+                  {report.fail} fail
+                </span>
+                <span className="text-amber-600 dark:text-amber-400">
+                  {report.warn} warn
+                </span>
+                <span className="text-emerald-600 dark:text-emerald-400">
+                  {report.pass} pass
+                </span>
+              </div>
+              {typeof report.domainRating === "number" && (
+                <p className="mt-3 text-sm text-muted-foreground">
+                  DR {Math.round(report.domainRating)} ·{" "}
+                  <Link
+                    href={AHREFS_DR_ATTRIBUTION.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline underline-offset-2"
+                  >
+                    {AHREFS_DR_ATTRIBUTION.text}
+                  </Link>
+                </p>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <Button type="button" variant="outline" size="sm" onClick={copyReport}>
+                {copied ? (
+                  <>
+                    <Check className="h-3.5 w-3.5 mr-1.5" /> Copied
+                  </>
+                ) : (
+                  <>
+                    <Copy className="h-3.5 w-3.5 mr-1.5" /> Copy report
+                  </>
+                )}
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => void run(value)}
+              >
+                Re-run
+              </Button>
+            </div>
+          </header>
+
+          {report.fixFirst.length > 0 && (
+            <section>
+              <h3 className="text-lg font-semibold">Fix first</h3>
+              <p className="text-sm text-muted-foreground mt-1">
+                Highest-impact issues, ordered by severity.
+              </p>
+              <div className="mt-4 rounded-lg border px-4">
+                {report.fixFirst.map((check) => (
+                  <CheckRow key={check.id} check={check} />
+                ))}
+              </div>
+            </section>
+          )}
+
+          <section className="space-y-4">
+            <h3 className="text-lg font-semibold">All checks</h3>
+            {report.categories.map((cat) => {
+              const open = openCats[cat.id] ?? true
+              return (
+                <div key={cat.id} className="rounded-lg border overflow-hidden">
+                  <button
+                    type="button"
+                    className="w-full flex items-center justify-between gap-3 px-4 py-3 text-left hover:bg-muted/40 transition-colors"
+                    onClick={() =>
+                      setOpenCats((prev) => ({ ...prev, [cat.id]: !open }))
+                    }
+                    aria-expanded={open}
+                  >
+                    <div>
+                      <span className="font-medium">{cat.label}</span>
+                      <span className="ml-2 font-mono text-sm text-muted-foreground">
+                        {cat.score}/100
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3 text-xs font-mono text-muted-foreground">
+                      <span className="text-red-600 dark:text-red-400">
+                        {cat.fail}
+                      </span>
+                      <span className="text-amber-600 dark:text-amber-400">
+                        {cat.warn}
+                      </span>
+                      <span className="text-emerald-600 dark:text-emerald-400">
+                        {cat.pass}
+                      </span>
+                      <ChevronDown
+                        className={cn(
+                          "h-4 w-4 transition-transform",
+                          open && "rotate-180"
+                        )}
+                      />
+                    </div>
+                  </button>
+                  {open && (
+                    <div className="px-4 border-t bg-muted/20">
+                      {cat.checks.map((check) => (
+                        <CheckRow key={check.id} check={check} />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </section>
+        </FadeIn>
+      )}
+    </div>
+  )
+}

--- a/app/(tools)/audit/audit-client.tsx
+++ b/app/(tools)/audit/audit-client.tsx
@@ -7,7 +7,21 @@ import { FadeIn } from "@/components/motion"
 import { AHREFS_DR_ATTRIBUTION } from "@/lib/ahrefs-dr"
 import type { AuditCheck, AuditReport, CheckStatus } from "@/lib/audit/types"
 import { cn } from "@/lib/utils"
-import { Check, ChevronDown, Copy, ExternalLink, Loader } from "lucide-react"
+import {
+  AlertTriangle,
+  Check,
+  CheckCircle2,
+  ChevronDown,
+  Copy,
+  ExternalLink,
+  FileSearch,
+  Globe2,
+  Loader,
+  RefreshCw,
+  Shield,
+  TrendingUp,
+  XCircle,
+} from "lucide-react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
@@ -29,11 +43,36 @@ function statusColor(status: CheckStatus) {
   return "text-red-600 dark:text-red-400"
 }
 
-function statusDot(status: CheckStatus) {
-  if (status === "pass") return "bg-emerald-500"
-  if (status === "warn") return "bg-amber-500"
-  return "bg-red-500"
+function StatusIcon({ status }: { status: CheckStatus }) {
+  if (status === "pass") {
+    return (
+      <CheckCircle2
+        className="h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400 mt-0.5"
+        aria-hidden
+      />
+    )
+  }
+  if (status === "warn") {
+    return (
+      <AlertTriangle
+        className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400 mt-0.5"
+        aria-hidden
+      />
+    )
+  }
+  return (
+    <XCircle
+      className="h-4 w-4 shrink-0 text-red-600 dark:text-red-400 mt-0.5"
+      aria-hidden
+    />
+  )
 }
+
+const categoryIcon = {
+  onpage: FileSearch,
+  crawl: Globe2,
+  trust: Shield,
+} as const
 
 function reportToMarkdown(report: AuditReport): string {
   const lines = [
@@ -65,12 +104,9 @@ function reportToMarkdown(report: AuditReport): string {
 
 function CheckRow({ check }: { check: AuditCheck }) {
   return (
-    <div className="flex flex-col sm:flex-row sm:items-start gap-2 py-3 border-b border-border/60 last:border-0">
-      <div className="flex items-start gap-2 min-w-0 flex-1">
-        <span
-          className={cn("mt-1.5 h-2 w-2 rounded-full shrink-0", statusDot(check.status))}
-          aria-hidden
-        />
+    <div className="flex flex-col sm:flex-row sm:items-start gap-2 py-3.5 border-b border-border/60 last:border-0">
+      <div className="flex items-start gap-2.5 min-w-0 flex-1">
+        <StatusIcon status={check.status} />
         <div className="min-w-0">
           <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
             <span className="font-medium text-sm">{check.label}</span>
@@ -233,80 +269,123 @@ export default function AuditClient({ query }: { query: string }) {
 
       {report && !loading && (
         <FadeIn className="mt-10 space-y-10">
-          <header className="flex flex-col sm:flex-row sm:items-end justify-between gap-4">
-            <div>
-              <p className="font-mono text-sm text-muted-foreground">
-                {report.domain}
-              </p>
-              <p className="text-xs text-muted-foreground mt-1">
-                {new Date(report.auditedAt).toLocaleString()}
-              </p>
-              <div className="mt-4 flex items-baseline gap-3">
-                <span className="text-6xl font-bold font-mono tracking-tight">
-                  {report.score}
-                </span>
-                <span className="text-muted-foreground text-sm">/ 100</span>
+          <header className="space-y-6">
+            <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+              <div className="min-w-0">
+                <p className="font-mono text-sm font-medium truncate">
+                  {report.domain}
+                </p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {new Date(report.auditedAt).toLocaleString()}
+                </p>
               </div>
-              <div className="mt-3 flex gap-4 text-xs font-mono">
-                <span className="text-red-600 dark:text-red-400">
-                  {report.fail} fail
-                </span>
-                <span className="text-amber-600 dark:text-amber-400">
-                  {report.warn} warn
-                </span>
-                <span className="text-emerald-600 dark:text-emerald-400">
-                  {report.pass} pass
-                </span>
+              <div className="flex gap-2 shrink-0">
+                <Button type="button" variant="outline" size="sm" onClick={copyReport}>
+                  {copied ? (
+                    <>
+                      <Check className="h-3.5 w-3.5 mr-1.5" /> Copied
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="h-3.5 w-3.5 mr-1.5" /> Copy report
+                    </>
+                  )}
+                </Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => void run(value)}
+                >
+                  <RefreshCw className="h-3.5 w-3.5 mr-1.5" />
+                  Re-run
+                </Button>
               </div>
-              {typeof report.domainRating === "number" && (
-                <p className="mt-3 text-sm text-muted-foreground">
-                  DR {Math.round(report.domainRating)} ·{" "}
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="rounded-xl border bg-muted/20 px-5 py-6 sm:px-6 sm:py-8">
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <TrendingUp className="h-4 w-4" aria-hidden />
+                  <span className="text-xs font-mono uppercase tracking-wider">
+                    Domain Rating
+                  </span>
+                </div>
+                <div className="mt-3 flex items-baseline gap-2">
+                  <span className="text-7xl sm:text-8xl font-bold font-mono tracking-tighter leading-none">
+                    {typeof report.domainRating === "number"
+                      ? Math.round(report.domainRating)
+                      : "—"}
+                  </span>
+                  <span className="text-muted-foreground text-sm font-mono">
+                    / 100
+                  </span>
+                </div>
+                {typeof report.domainRating !== "number" && (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {report.domainRatingError || "Unavailable"}
+                  </p>
+                )}
+                <div className="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
                   <Link
+                    href={`/domain-rating?q=${encodeURIComponent(report.domain)}`}
+                    className="inline-flex items-center gap-1 hover:text-foreground underline underline-offset-2"
+                  >
+                    Open DR tool <ExternalLink className="h-3 w-3" />
+                  </Link>
+                  <span className="opacity-60" aria-hidden>
+                    ·
+                  </span>
+                  <a
                     href={AHREFS_DR_ATTRIBUTION.href}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="underline underline-offset-2"
+                    className="opacity-60 hover:opacity-100 hover:text-foreground"
                   >
-                    {AHREFS_DR_ATTRIBUTION.text}
-                  </Link>
-                  {" · "}
-                  <Link
-                    href={AHREFS_DR_ATTRIBUTION.license}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline underline-offset-2"
-                  >
-                    License
-                  </Link>
-                </p>
-              )}
-            </div>
-            <div className="flex gap-2">
-              <Button type="button" variant="outline" size="sm" onClick={copyReport}>
-                {copied ? (
-                  <>
-                    <Check className="h-3.5 w-3.5 mr-1.5" /> Copied
-                  </>
-                ) : (
-                  <>
-                    <Copy className="h-3.5 w-3.5 mr-1.5" /> Copy report
-                  </>
-                )}
-              </Button>
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={() => void run(value)}
-              >
-                Re-run
-              </Button>
+                    Ahrefs
+                  </a>
+                </div>
+              </div>
+
+              <div className="rounded-xl border px-5 py-6 sm:px-6 sm:py-8">
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <Shield className="h-4 w-4" aria-hidden />
+                  <span className="text-xs font-mono uppercase tracking-wider">
+                    Audit score
+                  </span>
+                </div>
+                <div className="mt-3 flex items-baseline gap-2">
+                  <span className="text-5xl sm:text-6xl font-bold font-mono tracking-tighter leading-none">
+                    {report.score}
+                  </span>
+                  <span className="text-muted-foreground text-sm font-mono">
+                    / 100
+                  </span>
+                </div>
+                <div className="mt-5 flex flex-wrap gap-3 text-xs font-mono">
+                  <span className="inline-flex items-center gap-1.5 text-red-600 dark:text-red-400">
+                    <XCircle className="h-3.5 w-3.5" aria-hidden />
+                    {report.fail} fail
+                  </span>
+                  <span className="inline-flex items-center gap-1.5 text-amber-600 dark:text-amber-400">
+                    <AlertTriangle className="h-3.5 w-3.5" aria-hidden />
+                    {report.warn} warn
+                  </span>
+                  <span className="inline-flex items-center gap-1.5 text-emerald-600 dark:text-emerald-400">
+                    <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
+                    {report.pass} pass
+                  </span>
+                </div>
+              </div>
             </div>
           </header>
 
           {report.fixFirst.length > 0 && (
             <section>
-              <h3 className="text-lg font-semibold">Fix first</h3>
+              <div className="flex items-center gap-2">
+                <AlertTriangle className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+                <h3 className="text-lg font-semibold">Fix first</h3>
+              </div>
               <p className="text-sm text-muted-foreground mt-1">
                 Highest-impact issues, ordered by severity.
               </p>
@@ -322,6 +401,7 @@ export default function AuditClient({ query }: { query: string }) {
             <h3 className="text-lg font-semibold">All checks</h3>
             {report.categories.map((cat) => {
               const open = openCats[cat.id] ?? true
+              const CatIcon = categoryIcon[cat.id]
               return (
                 <div key={cat.id} className="rounded-lg border overflow-hidden">
                   <button
@@ -332,20 +412,27 @@ export default function AuditClient({ query }: { query: string }) {
                     }
                     aria-expanded={open}
                   >
-                    <div>
+                    <div className="flex items-center gap-2.5 min-w-0">
+                      <CatIcon
+                        className="h-4 w-4 shrink-0 text-muted-foreground"
+                        aria-hidden
+                      />
                       <span className="font-medium">{cat.label}</span>
-                      <span className="ml-2 font-mono text-sm text-muted-foreground">
+                      <span className="font-mono text-sm text-muted-foreground">
                         {cat.score}/100
                       </span>
                     </div>
                     <div className="flex items-center gap-3 text-xs font-mono text-muted-foreground">
-                      <span className="text-red-600 dark:text-red-400">
+                      <span className="inline-flex items-center gap-1 text-red-600 dark:text-red-400">
+                        <XCircle className="h-3 w-3" />
                         {cat.fail}
                       </span>
-                      <span className="text-amber-600 dark:text-amber-400">
+                      <span className="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400">
+                        <AlertTriangle className="h-3 w-3" />
                         {cat.warn}
                       </span>
-                      <span className="text-emerald-600 dark:text-emerald-400">
+                      <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+                        <CheckCircle2 className="h-3 w-3" />
                         {cat.pass}
                       </span>
                       <ChevronDown

--- a/app/(tools)/audit/audit-client.tsx
+++ b/app/(tools)/audit/audit-client.tsx
@@ -19,6 +19,7 @@ import {
   Loader,
   RefreshCw,
   Shield,
+  Sparkles,
   TrendingUp,
   XCircle,
 } from "lucide-react"
@@ -102,6 +103,53 @@ function reportToMarkdown(report: AuditReport): string {
   return lines.filter((l) => l !== null).join("\n")
 }
 
+function reportToAiPrompt(report: AuditReport): string {
+  const drLine =
+    typeof report.domainRating === "number"
+      ? `- Domain Rating: ${Math.round(report.domainRating)}/100`
+      : null
+
+  const fixFirst =
+    report.fixFirst.length > 0
+      ? report.fixFirst.flatMap((c) => [
+          `- [${c.status.toUpperCase()}] ${c.label}`,
+          `  Detail: ${c.detail}`,
+          ...(c.value ? [`  Value: ${c.value}`] : []),
+          `  Fix hint: ${c.fixHint}`,
+        ])
+      : ["(No failing or warning checks — review category summaries below.)"]
+
+  const categorySummaries = report.categories.map(
+    (cat) =>
+      `- ${cat.label}: ${cat.score}/100 (${cat.fail} fail, ${cat.warn} warn, ${cat.pass} pass)`
+  )
+
+  const lines = [
+    "You are an experienced SEO engineer. Use this site audit report to produce a concrete remediation plan.",
+    "",
+    "## Site",
+    `- Domain: ${report.domain}`,
+    `- URL audited: ${report.finalUrl}`,
+    drLine,
+    `- Overall audit score: ${report.score}/100`,
+    `- Checks: ${report.fail} fail, ${report.warn} warn, ${report.pass} pass`,
+    "",
+    "## Instructions",
+    "- Prioritize FAIL issues first, then WARN. Skip or briefly note PASS items.",
+    "- Give concrete code or config changes (e.g. robots.txt, meta tags, canonicals, HTTP headers, sitemap.xml, JSON-LD).",
+    "- Tie each recommendation to a finding in this report. Do not invent PageSpeed, Core Web Vitals, or other claims not present here.",
+    "- Prefer actionable snippets and file-level guidance over generic SEO advice.",
+    "",
+    "## Fix first (highest impact)",
+    ...fixFirst,
+    "",
+    "## Category summaries",
+    ...categorySummaries,
+  ]
+
+  return lines.filter((l) => l !== null).join("\n")
+}
+
 function CheckRow({ check }: { check: AuditCheck }) {
   return (
     <div className="flex flex-col sm:flex-row sm:items-start gap-2 py-3.5 border-b border-border/60 last:border-0">
@@ -152,6 +200,7 @@ export default function AuditClient({ query }: { query: string }) {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
+  const [promptCopied, setPromptCopied] = useState(false)
   const [openCats, setOpenCats] = useState<Record<string, boolean>>({
     onpage: true,
     crawl: true,
@@ -213,6 +262,13 @@ export default function AuditClient({ query }: { query: string }) {
     await navigator.clipboard.writeText(reportToMarkdown(report))
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
+  }
+
+  const copyAiPrompt = async () => {
+    if (!report) return
+    await navigator.clipboard.writeText(reportToAiPrompt(report))
+    setPromptCopied(true)
+    setTimeout(() => setPromptCopied(false), 2000)
   }
 
   return (
@@ -279,7 +335,7 @@ export default function AuditClient({ query }: { query: string }) {
                   {new Date(report.auditedAt).toLocaleString()}
                 </p>
               </div>
-              <div className="flex gap-2 shrink-0">
+              <div className="flex flex-wrap gap-2 shrink-0">
                 <Button type="button" variant="outline" size="sm" onClick={copyReport}>
                   {copied ? (
                     <>
@@ -288,6 +344,22 @@ export default function AuditClient({ query }: { query: string }) {
                   ) : (
                     <>
                       <Copy className="h-3.5 w-3.5 mr-1.5" /> Copy report
+                    </>
+                  )}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void copyAiPrompt()}
+                >
+                  {promptCopied ? (
+                    <>
+                      <Check className="h-3.5 w-3.5 mr-1.5" /> Prompt copied
+                    </>
+                  ) : (
+                    <>
+                      <Sparkles className="h-3.5 w-3.5 mr-1.5" /> Fix with AI
                     </>
                   )}
                 </Button>

--- a/app/(tools)/audit/page.tsx
+++ b/app/(tools)/audit/page.tsx
@@ -5,16 +5,35 @@ import { constructMetadata } from "@/lib/utils"
 import { FadeIn } from "@/components/motion"
 import { safeDecodeURIComponent } from "@/lib/safe-decode"
 import AuditClient from "./audit-client"
+import JsonLd from "@/components/json-ld"
+import ToolRelatedLinks from "@/components/tool-related-links"
+import { absoluteUrl, features } from "@/lib/site"
+
+const feature = features.audit
 
 export const metadata: Metadata = constructMetadata({
-  title: "Free Site Audit | SeoCheckup",
-  description:
-    "Free website SEO audit: robots, sitemap, meta tags, security headers, and Ahrefs Domain Rating in one report.",
-  canonical: "/audit",
+  title: "Free Website SEO Audit | SeoCheckup",
+  description: feature.description,
+  canonical: feature.toolPath,
   ogImage: "/og-dark.png",
 })
 
 export const revalidate = 0
+
+const appJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: feature.appName,
+  url: absoluteUrl(feature.toolPath),
+  applicationCategory: "BusinessApplication",
+  operatingSystem: "Any",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+  description: feature.description,
+}
 
 export default async function AuditPage({
   searchParams,
@@ -26,6 +45,7 @@ export default async function AuditPage({
 
   return (
     <div className="min-h-screen max-h-full flex items-center flex-col pb-16 px-4 md:px-0">
+      <JsonLd data={appJsonLd} />
       <FadeIn>
         <section className="flex justify-center flex-col items-center gap-4 mt-3">
           <div
@@ -42,6 +62,7 @@ export default async function AuditPage({
         </section>
       </FadeIn>
       <AuditClient key={query || "default"} query={query} />
+      <ToolRelatedLinks feature="audit" />
     </div>
   )
 }

--- a/app/(tools)/audit/page.tsx
+++ b/app/(tools)/audit/page.tsx
@@ -1,0 +1,47 @@
+import React from "react"
+import { Stethoscope } from "lucide-react"
+import type { Metadata } from "next"
+import { constructMetadata } from "@/lib/utils"
+import { FadeIn } from "@/components/motion"
+import { safeDecodeURIComponent } from "@/lib/safe-decode"
+import AuditClient from "./audit-client"
+
+export const metadata: Metadata = constructMetadata({
+  title: "Free Site Audit | SeoCheckup",
+  description:
+    "Free website SEO audit: robots, sitemap, meta tags, security headers, and Ahrefs Domain Rating in one report.",
+  canonical: "/audit",
+  ogImage: "/og-dark.png",
+})
+
+export const revalidate = 0
+
+export default async function AuditPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>
+}) {
+  const { q } = await searchParams
+  const query = safeDecodeURIComponent(q)
+
+  return (
+    <div className="min-h-screen max-h-full flex items-center flex-col pb-16 px-4 md:px-0">
+      <FadeIn>
+        <section className="flex justify-center flex-col items-center gap-4 mt-3">
+          <div
+            className="w-11 h-11 flex justify-center items-center rounded-lg
+         bg-gradient-to-br from-secondary via-black/20 to-secondary/20 dark:from-primary/30 dark:via-primary/50 dark:to-primary text-black backdrop-blur-md"
+          >
+            <Stethoscope />
+          </div>
+          <h2 className="text-center text-2xl font-semibold">Site Audit</h2>
+          <p className="text-sm text-muted-foreground text-center max-w-md">
+            One URL. Robots, sitemap, on-page signals, headers, and Domain Rating —
+            free, no lockouts.
+          </p>
+        </section>
+      </FadeIn>
+      <AuditClient key={query || "default"} query={query} />
+    </div>
+  )
+}

--- a/app/(tools)/domain-rating/domain-rating-client.tsx
+++ b/app/(tools)/domain-rating/domain-rating-client.tsx
@@ -1,0 +1,146 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import { FadeIn } from "@/components/motion"
+import { AHREFS_DR_ATTRIBUTION } from "@/lib/ahrefs-dr"
+import { logToolUsage } from "@/lib/log-tool-usage"
+import { Loader } from "lucide-react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+const DEFAULT_SITE = "https://shrix1.com"
+
+function initialQuery(query: string) {
+  if (!query) return DEFAULT_SITE
+  try {
+    return decodeURIComponent(query)
+  } catch {
+    return query
+  }
+}
+
+export default function DomainRatingClient({ query }: { query: string }) {
+  const router = useRouter()
+  const initial = useMemo(() => initialQuery(query), [query])
+  const [value, setValue] = useState(initial)
+  const [domain, setDomain] = useState<string | null>(null)
+  const [rating, setRating] = useState<number | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const hasFetched = useRef(false)
+
+  const run = useCallback(async (url: string) => {
+    if (!url.trim()) {
+      setError("Enter a domain or URL")
+      return
+    }
+    setLoading(true)
+    setError(null)
+    setRating(null)
+    setDomain(null)
+    try {
+      const res = await fetch(
+        `/api/domain-rating?q=${encodeURIComponent(url.trim())}`
+      )
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error || "Could not load Domain Rating")
+        if (data.domain) setDomain(data.domain)
+        return
+      }
+      setDomain(data.domain)
+      setRating(data.domainRating)
+      void logToolUsage(url.trim(), "DOMAIN_RATING")
+    } catch {
+      setError("Could not load Domain Rating")
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (hasFetched.current) return
+    hasFetched.current = true
+    void run(initial)
+  }, [initial, run])
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const next = value.trim()
+    router.push(`/domain-rating?q=${encodeURIComponent(next)}`)
+    void run(next)
+  }
+
+  return (
+    <div className="w-full max-w-xl mx-auto mt-8">
+      <form onSubmit={onSubmit} className="flex flex-col sm:flex-row gap-2">
+        <Input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="example.com"
+          className="font-mono"
+          aria-label="Domain to check"
+        />
+        <Button type="submit" disabled={loading} className="shrink-0">
+          {loading ? (
+            <>
+              <Loader className="h-4 w-4 animate-spin mr-2" />
+              Checking…
+            </>
+          ) : (
+            "Check DR"
+          )}
+        </Button>
+      </form>
+
+      {error && (
+        <p className="mt-6 text-sm text-red-600 dark:text-red-400">{error}</p>
+      )}
+
+      {loading && (
+        <div className="mt-10 space-y-3">
+          <Skeleton className="h-20 w-32" />
+          <Skeleton className="h-4 w-48" />
+        </div>
+      )}
+
+      {typeof rating === "number" && !loading && (
+        <FadeIn className="mt-12">
+          <p className="font-mono text-sm text-muted-foreground">{domain}</p>
+          <div className="mt-2 flex items-baseline gap-2">
+            <span className="text-7xl font-bold font-mono tracking-tight">
+              {Math.round(rating)}
+            </span>
+            <span className="text-muted-foreground">/ 100</span>
+          </div>
+          <p className="mt-4 text-sm text-muted-foreground max-w-md">
+            Domain Rating estimates relative backlink profile strength on a
+            100-point logarithmic scale.
+          </p>
+          <p className="mt-3 text-sm">
+            <Link
+              href={AHREFS_DR_ATTRIBUTION.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-2"
+            >
+              {AHREFS_DR_ATTRIBUTION.text}
+            </Link>
+          </p>
+          <div className="mt-8">
+            <Button asChild>
+              <Link
+                href={`/audit?q=${encodeURIComponent(domain ? `https://${domain}` : value)}`}
+              >
+                Run full site audit
+              </Link>
+            </Button>
+          </div>
+        </FadeIn>
+      )}
+    </div>
+  )
+}

--- a/app/(tools)/domain-rating/domain-rating-client.tsx
+++ b/app/(tools)/domain-rating/domain-rating-client.tsx
@@ -5,7 +5,6 @@ import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { FadeIn } from "@/components/motion"
 import { AHREFS_DR_ATTRIBUTION } from "@/lib/ahrefs-dr"
-import { logToolUsage } from "@/lib/log-tool-usage"
 import { Loader } from "lucide-react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
@@ -28,7 +27,7 @@ export default function DomainRatingClient({ query }: { query: string }) {
   const [value, setValue] = useState(initial)
   const [domain, setDomain] = useState<string | null>(null)
   const [rating, setRating] = useState<number | null>(null)
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const hasFetched = useRef(false)
 
@@ -46,6 +45,15 @@ export default function DomainRatingClient({ query }: { query: string }) {
         `/api/domain-rating?q=${encodeURIComponent(url.trim())}`
       )
       const data = await res.json()
+      if (res.status === 429 || data.error === "Rate limit exceeded") {
+        const resetMs = data.reset
+        const hours =
+          typeof resetMs === "number"
+            ? Math.max(1, Math.ceil((resetMs - Date.now()) / 3_600_000))
+            : "?"
+        setError(`Rate limit exceeded. Try again in ${hours} hours.`)
+        return
+      }
       if (!res.ok) {
         setError(data.error || "Could not load Domain Rating")
         if (data.domain) setDomain(data.domain)
@@ -53,7 +61,6 @@ export default function DomainRatingClient({ query }: { query: string }) {
       }
       setDomain(data.domain)
       setRating(data.domainRating)
-      void logToolUsage(url.trim(), "DOMAIN_RATING")
     } catch {
       setError("Could not load Domain Rating")
     } finally {
@@ -69,9 +76,12 @@ export default function DomainRatingClient({ query }: { query: string }) {
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    const next = value.trim()
+    const next = value.trim() || DEFAULT_SITE
+    if (next === initial) {
+      void run(next)
+      return
+    }
     router.push(`/domain-rating?q=${encodeURIComponent(next)}`)
-    void run(next)
   }
 
   return (
@@ -128,6 +138,15 @@ export default function DomainRatingClient({ query }: { query: string }) {
               className="underline underline-offset-2"
             >
               {AHREFS_DR_ATTRIBUTION.text}
+            </Link>
+            {" · "}
+            <Link
+              href={AHREFS_DR_ATTRIBUTION.license}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-2 text-muted-foreground"
+            >
+              License
             </Link>
           </p>
           <div className="mt-8">

--- a/app/(tools)/domain-rating/page.tsx
+++ b/app/(tools)/domain-rating/page.tsx
@@ -1,0 +1,48 @@
+import React from "react"
+import { TrendingUp } from "lucide-react"
+import type { Metadata } from "next"
+import { constructMetadata } from "@/lib/utils"
+import { FadeIn } from "@/components/motion"
+import { safeDecodeURIComponent } from "@/lib/safe-decode"
+import DomainRatingClient from "./domain-rating-client"
+
+export const metadata: Metadata = constructMetadata({
+  title: "Free Domain Rating Checker | SeoCheckup",
+  description:
+    "Check Ahrefs Domain Rating (DR) for any domain free. Instant authority score with required Ahrefs attribution.",
+  canonical: "/domain-rating",
+  ogImage: "/og-dark.png",
+})
+
+export const revalidate = 0
+
+export default async function DomainRatingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>
+}) {
+  const { q } = await searchParams
+  const query = safeDecodeURIComponent(q)
+
+  return (
+    <div className="min-h-screen max-h-full flex items-center flex-col pb-16 px-4 md:px-0">
+      <FadeIn>
+        <section className="flex justify-center flex-col items-center gap-4 mt-3">
+          <div
+            className="w-11 h-11 flex justify-center items-center rounded-lg
+         bg-gradient-to-br from-secondary via-black/20 to-secondary/20 dark:from-primary/30 dark:via-primary/50 dark:to-primary text-black backdrop-blur-md"
+          >
+            <TrendingUp />
+          </div>
+          <h2 className="text-center text-2xl font-semibold">
+            Domain Rating Checker
+          </h2>
+          <p className="text-sm text-muted-foreground text-center max-w-md">
+            Free Ahrefs Domain Rating lookup. No API key required.
+          </p>
+        </section>
+      </FadeIn>
+      <DomainRatingClient key={query || "default"} query={query} />
+    </div>
+  )
+}

--- a/app/(tools)/domain-rating/page.tsx
+++ b/app/(tools)/domain-rating/page.tsx
@@ -5,16 +5,35 @@ import { constructMetadata } from "@/lib/utils"
 import { FadeIn } from "@/components/motion"
 import { safeDecodeURIComponent } from "@/lib/safe-decode"
 import DomainRatingClient from "./domain-rating-client"
+import JsonLd from "@/components/json-ld"
+import ToolRelatedLinks from "@/components/tool-related-links"
+import { absoluteUrl, features } from "@/lib/site"
+
+const feature = features.domainRating
 
 export const metadata: Metadata = constructMetadata({
   title: "Free Domain Rating Checker | SeoCheckup",
-  description:
-    "Check Ahrefs Domain Rating (DR) for any domain free. Instant authority score with required Ahrefs attribution.",
-  canonical: "/domain-rating",
+  description: feature.description,
+  canonical: feature.toolPath,
   ogImage: "/og-dark.png",
 })
 
 export const revalidate = 0
+
+const appJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: feature.appName,
+  url: absoluteUrl(feature.toolPath),
+  applicationCategory: "BusinessApplication",
+  operatingSystem: "Any",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+  description: feature.description,
+}
 
 export default async function DomainRatingPage({
   searchParams,
@@ -26,6 +45,7 @@ export default async function DomainRatingPage({
 
   return (
     <div className="min-h-screen max-h-full flex items-center flex-col pb-16 px-4 md:px-0">
+      <JsonLd data={appJsonLd} />
       <FadeIn>
         <section className="flex justify-center flex-col items-center gap-4 mt-3">
           <div
@@ -43,6 +63,7 @@ export default async function DomainRatingPage({
         </section>
       </FadeIn>
       <DomainRatingClient key={query || "default"} query={query} />
+      <ToolRelatedLinks feature="domainRating" />
     </div>
   )
 }

--- a/app/(tools)/metadata/input-field.tsx
+++ b/app/(tools)/metadata/input-field.tsx
@@ -6,7 +6,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import Image from "next/image"
 import { Loader, Image as ImageIcon } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { logToolUsage } from "@/lib/log-tool-usage"
 import Link from "next/link"
 
 const DEFAULT_SITE = "https://shrix1.com"
@@ -40,7 +39,9 @@ const InputFieldMetadata = ({ query }: { query: string }) => {
     try {
       setLoading(true)
       setError(false)
-      const data = await fetch(`/api/v1?q=${encodeURIComponent(target)}`)
+      const data = await fetch(
+        `/api/v1?q=${encodeURIComponent(target)}&tool=METADATA`
+      )
       const jsonData = await data.json()
 
       if (data.status === 429 || jsonData.error === "Rate limit exceeded") {
@@ -57,8 +58,6 @@ const InputFieldMetadata = ({ query }: { query: string }) => {
         setError(true)
         return
       }
-
-      await logToolUsage(target, "METADATA")
 
       const tempDiv = document.createElement("div")
       tempDiv.innerHTML = jsonData

--- a/app/(tools)/metadata/input-field.tsx
+++ b/app/(tools)/metadata/input-field.tsx
@@ -1,89 +1,106 @@
-"use client";
-import { Input } from "@/components/ui/input";
-import { useRouter } from "next/navigation";
-import React, { useEffect, useState } from "react";
-import Image from "next/image";
-import { Loader, Image as ImageIcon } from "lucide-react";
-import { cn } from "@/lib/utils";
-import { postDiscordLogs } from "@/lib/discord-webhook";
-import Link from "next/link";
+"use client"
+
+import { Input } from "@/components/ui/input"
+import { useRouter } from "next/navigation"
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import Image from "next/image"
+import { Loader, Image as ImageIcon } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { logToolUsage } from "@/lib/log-tool-usage"
+import Link from "next/link"
+
+const DEFAULT_SITE = "https://freetoolsfr.com"
+
+function initialQuery(query: string) {
+  if (!query) return DEFAULT_SITE
+  try {
+    return decodeURIComponent(query)
+  } catch {
+    return query
+  }
+}
 
 const InputFieldMetadata = ({ query }: { query: string }) => {
-  const router = useRouter();
-  const [value, setValue] = useState("");
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
-  const [ogImage, setOgImage] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(false);
-  const [url, setUrl] = useState("");
+  const router = useRouter()
+  const initial = useMemo(() => initialQuery(query), [query])
+  const [value, setValue] = useState(initial)
+  const [title, setTitle] = useState("")
+  const [description, setDescription] = useState("")
+  const [ogImage, setOgImage] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(false)
+  const [url, setUrl] = useState("")
+  const hasFetched = useRef(false)
 
-  useEffect(() => {
-    const q = decodeURIComponent(query);
-    setValue(q || "https://freetoolsfr.com");
-  }, [query]);
-
-  useEffect(() => {
-    (async () => {
-      await handleSubmit();
-    })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    if (value) {
-      router.push(`/metadata?q=${encodeURIComponent(value)}`);
+  const fetchMetadata = useCallback(async (target: string) => {
+    if (!target) {
+      setError(true)
+      return
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value]);
-
-  async function handleSubmit() {
     try {
-      setLoading(true);
-      const data = await fetch(`/api/v1?q=${decodeURIComponent(query)}`);
-      const jsonData = await data.json();
-      if (jsonData.error === "Rate limit exceeded") {
-        alert(
-          "You reached the limit, try again in " +
-          jsonData.data.reset +
-          " hours or try again later"
-        );
-        return [];
+      setLoading(true)
+      setError(false)
+      const data = await fetch(`/api/v1?q=${encodeURIComponent(target)}`)
+      const jsonData = await data.json()
+
+      if (data.status === 429 || jsonData.error === "Rate limit exceeded") {
+        const resetMs = jsonData.reset ?? jsonData.data?.reset
+        const hours =
+          typeof resetMs === "number"
+            ? Math.max(1, Math.ceil((resetMs - Date.now()) / 3_600_000))
+            : "?"
+        alert(`You reached the limit, try again in ${hours} hours or later`)
+        return
       }
-      await postDiscordLogs(decodeURIComponent(query), "METADATA");
 
-      const tempDiv = document.createElement("div");
-      tempDiv.innerHTML = jsonData;
+      if (!data.ok || typeof jsonData !== "string") {
+        setError(true)
+        return
+      }
 
-      const title = tempDiv.querySelector("title")?.textContent;
-      setTitle(title || "Untitled");
+      await logToolUsage(target, "METADATA")
 
-      const description = tempDiv
+      const tempDiv = document.createElement("div")
+      tempDiv.innerHTML = jsonData
+
+      const pageTitle = tempDiv.querySelector("title")?.textContent
+      setTitle(pageTitle || "Untitled")
+
+      const pageDescription = tempDiv
         .querySelector('meta[name="description"]')
-        ?.getAttribute("content");
-
-      setDescription(description || "Untitled");
+        ?.getAttribute("content")
+      setDescription(pageDescription || "Untitled")
 
       const ogImageUrl = tempDiv
         .querySelector('meta[property="og:image"]')
-        ?.getAttribute("content");
-      setOgImage(ogImageUrl || "");
+        ?.getAttribute("content")
+      setOgImage(ogImageUrl || "")
 
-      setUrl(value);
-    } catch (error) {
-      console.error("Error fetching metadata:", error);
-      setError(true);
+      setUrl(target)
+    } catch (err) {
+      console.error("Error fetching metadata:", err)
+      setError(true)
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  }
+  }, [])
+
+  useEffect(() => {
+    if (hasFetched.current) return
+    hasFetched.current = true
+    void fetchMetadata(initial)
+  }, [fetchMetadata, initial])
 
   return (
     <div className="w-full flex justify-center flex-col items-center px-4 md:px-0 ">
       <form
         onSubmit={async (e) => {
-          e.preventDefault();
-          await handleSubmit();
+          e.preventDefault()
+          if (value === initial) {
+            await fetchMetadata(value)
+            return
+          }
+          router.replace(`/metadata?q=${encodeURIComponent(value)}`)
         }}
         className="w-full md:w-[400px] flex justify-center my-6 items-center h-[70px] sticky top-2 rounded-lg flex-col"
       >
@@ -96,12 +113,10 @@ const InputFieldMetadata = ({ query }: { query: string }) => {
           className="text-base min-h-[50px] dark:bg-white font-mono text-white dark:text-black bg-black"
         />
       </form>
-      <p className="text-sm text-gray-500 mb-10 -mt-8">
+      <p className="text-sm text-muted-foreground mb-10 -mt-8">
         example url:{" "}
         <Link href="https://shrix1.com" target="_blank">
-          <span className="font-medium text-black dark:text-white">
-            https://shrix1.com
-          </span>
+          <span className="font-medium text-foreground">https://shrix1.com</span>
         </Link>
       </p>
 
@@ -129,19 +144,17 @@ const InputFieldMetadata = ({ query }: { query: string }) => {
           </MetaDataContainer>
 
           <MetaDataContainer title="X ( aka twitter )">
-            <div className="">
+            <div>
               <div className="relative">
                 <ImageContainer
                   ogImage={ogImage}
                   title={title}
                   className="rounded-xl"
                 />
-
                 <h3 className="text-xs max-w-[400px] rounded-md px-2 py-0.5 bg-black line-clamp-1 text-white absolute bottom-3 left-3">
                   {title}
                 </h3>
               </div>
-
               <p className="text-sm text-gray-500 mt-1">
                 From {url ? new URL(url)?.hostname : url}
               </p>
@@ -157,13 +170,11 @@ const InputFieldMetadata = ({ query }: { query: string }) => {
                   {description}
                 </p>
               </div>
-              <div>
-                <ImageContainer
-                  ogImage={ogImage}
-                  title={title}
-                  className="rounded-none"
-                />
-              </div>
+              <ImageContainer
+                ogImage={ogImage}
+                title={title}
+                className="rounded-none"
+              />
             </div>
           </MetaDataContainer>
 
@@ -186,7 +197,7 @@ const InputFieldMetadata = ({ query }: { query: string }) => {
           </MetaDataContainer>
 
           <MetaDataContainer title="Discord">
-            <div className="rounded-md bg-slate-100 dark:bg-gray-700 p-4 border-l-4 border-l-gray-400 dark:border-l-gray-400">
+            <div className="rounded-md bg-slate-100 dark:bg-gray-700 p-4 border-l-4 border-l-gray-400">
               <h3 className="line-clamp-1 text-blue-500">{title}</h3>
               <p className="text-sm text-gray-500 dark:text-white line-clamp-3">
                 {description}
@@ -222,17 +233,17 @@ const InputFieldMetadata = ({ query }: { query: string }) => {
         </section>
       )}
     </div>
-  );
-};
+  )
+}
 
-export default InputFieldMetadata;
+export default InputFieldMetadata
 
 function MetaDataContainer({
   title,
   children,
 }: {
-  title: string;
-  children: React.ReactNode;
+  title: string
+  children: React.ReactNode
 }) {
   return (
     <div className="flex flex-col gap-2">
@@ -241,7 +252,7 @@ function MetaDataContainer({
       </h2>
       {children}
     </div>
-  );
+  )
 }
 
 function ImageContainer({
@@ -249,9 +260,9 @@ function ImageContainer({
   className,
   title,
 }: {
-  ogImage: string;
-  className: string;
-  title: string;
+  ogImage: string
+  className: string
+  title: string
 }) {
   return ogImage ? (
     <Image
@@ -265,5 +276,5 @@ function ImageContainer({
     <div className="w-[500px] h-[300px] bg-slate-200 grid place-items-center">
       <ImageIcon className="h-10 text-gray-400" />
     </div>
-  );
+  )
 }

--- a/app/(tools)/metadata/input-field.tsx
+++ b/app/(tools)/metadata/input-field.tsx
@@ -9,7 +9,7 @@ import { cn } from "@/lib/utils"
 import { logToolUsage } from "@/lib/log-tool-usage"
 import Link from "next/link"
 
-const DEFAULT_SITE = "https://freetoolsfr.com"
+const DEFAULT_SITE = "https://shrix1.com"
 
 function initialQuery(query: string) {
   if (!query) return DEFAULT_SITE

--- a/app/(tools)/metadata/page.tsx
+++ b/app/(tools)/metadata/page.tsx
@@ -1,33 +1,42 @@
-import React from "react";
-import { FileImage } from "lucide-react";
-import type { Metadata } from "next";
-import { constructMetadata } from "@/lib/utils";
-import InputFieldMetadata from "./input-field";
+import React from "react"
+import { FileImage } from "lucide-react"
+import type { Metadata } from "next"
+import { constructMetadata } from "@/lib/utils"
+import { FadeIn } from "@/components/motion"
+import { safeDecodeURIComponent } from "@/lib/safe-decode"
+import InputFieldMetadata from "./input-field"
 
 export const metadata: Metadata = constructMetadata({
   title: "Metdata Checker | SeoCheckup",
   description: "Easily review your metadata by adding your site link.",
   canonical: "/metadata",
   ogImage: "/og-dark.png",
-});
+})
 
-export const revalidate = 0;
+export const revalidate = 0
 
-const MetaData = ({ searchParams }: { searchParams: { q: string } }) => {
+export default async function MetaData({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>
+}) {
+  const { q } = await searchParams
+  const query = safeDecodeURIComponent(q)
+
   return (
     <div className="min-h-screen max-h-full flex items-center flex-col pb-10 px-4 md:px-0">
-      <section className="flex justify-center flex-col items-center gap-4 mt-3">
-        <div
-          className="w-11 h-11 flex justify-center items-center rounded-lg
-       bg-gradient-to-br from-secondary via-black/20 to-secondary/20 dark:from-primary/30 dark:via-primary/50 dark:to-primary text-black backdrop-blur-md"
-        >
-          <FileImage />
-        </div>
-        <h2 className="text-center text-2xl font-semibold">MetaData Checker</h2>
-        <InputFieldMetadata query={searchParams.q} />
-      </section>
+      <FadeIn>
+        <section className="flex justify-center flex-col items-center gap-4 mt-3">
+          <div
+            className="w-11 h-11 flex justify-center items-center rounded-lg
+         bg-gradient-to-br from-secondary via-black/20 to-secondary/20 dark:from-primary/30 dark:via-primary/50 dark:to-primary text-black backdrop-blur-md"
+          >
+            <FileImage />
+          </div>
+          <h2 className="text-center text-2xl font-semibold">MetaData Checker</h2>
+        </section>
+      </FadeIn>
+      <InputFieldMetadata key={query || "default"} query={query} />
     </div>
-  );
-};
-
-export default MetaData;
+  )
+}

--- a/app/(tools)/metadata/page.tsx
+++ b/app/(tools)/metadata/page.tsx
@@ -5,15 +5,35 @@ import { constructMetadata } from "@/lib/utils"
 import { FadeIn } from "@/components/motion"
 import { safeDecodeURIComponent } from "@/lib/safe-decode"
 import InputFieldMetadata from "./input-field"
+import JsonLd from "@/components/json-ld"
+import ToolRelatedLinks from "@/components/tool-related-links"
+import { absoluteUrl, features } from "@/lib/site"
+
+const feature = features.metadata
 
 export const metadata: Metadata = constructMetadata({
-  title: "Metdata Checker | SeoCheckup",
-  description: "Easily review your metadata by adding your site link.",
-  canonical: "/metadata",
+  title: "Free Meta Tags Checker | SeoCheckup",
+  description: feature.description,
+  canonical: feature.toolPath,
   ogImage: "/og-dark.png",
 })
 
 export const revalidate = 0
+
+const appJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: feature.appName,
+  url: absoluteUrl(feature.toolPath),
+  applicationCategory: "BusinessApplication",
+  operatingSystem: "Any",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+  description: feature.description,
+}
 
 export default async function MetaData({
   searchParams,
@@ -25,6 +45,7 @@ export default async function MetaData({
 
   return (
     <div className="min-h-screen max-h-full flex items-center flex-col pb-10 px-4 md:px-0">
+      <JsonLd data={appJsonLd} />
       <FadeIn>
         <section className="flex justify-center flex-col items-center gap-4 mt-3">
           <div
@@ -33,10 +54,14 @@ export default async function MetaData({
           >
             <FileImage />
           </div>
-          <h2 className="text-center text-2xl font-semibold">MetaData Checker</h2>
+          <h2 className="text-center text-2xl font-semibold">Meta Tags Checker</h2>
+          <p className="text-sm text-muted-foreground text-center max-w-md">
+            Preview title, description, and Open Graph cards before you publish.
+          </p>
         </section>
       </FadeIn>
       <InputFieldMetadata key={query || "default"} query={query} />
+      <ToolRelatedLinks feature="metadata" />
     </div>
   )
 }

--- a/app/(tools)/robots/input-field.tsx
+++ b/app/(tools)/robots/input-field.tsx
@@ -1,0 +1,208 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import { FadeIn } from "@/components/motion"
+import { logToolUsage } from "@/lib/log-tool-usage"
+import { Check, Copy, Loader } from "lucide-react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+const DEFAULT_ROBOTS = "https://freetoolsfr.com/robots.txt"
+
+const DIRECTIVE =
+  /^(User-agent|Disallow|Allow|Sitemap|Crawl-delay|Host)\s*:/i
+
+function initialQuery(query: string) {
+  if (!query) return DEFAULT_ROBOTS
+  try {
+    return decodeURIComponent(query)
+  } catch {
+    return query
+  }
+}
+
+function HighlightedRobots({ text }: { text: string }) {
+  const lines = text.split(/\r?\n/)
+  return (
+    <pre className="text-left text-sm font-mono whitespace-pre-wrap break-words p-4 rounded-lg border bg-muted/40 max-w-3xl w-full overflow-x-auto">
+      {lines.map((line, i) => {
+        const trimmed = line.trim()
+        const isDirective = DIRECTIVE.test(trimmed)
+        const isComment = trimmed.startsWith("#")
+        return (
+          <div
+            key={i}
+            className={
+              isComment
+                ? "text-muted-foreground"
+                : isDirective
+                  ? "text-foreground"
+                  : "text-muted-foreground/90"
+            }
+          >
+            {isDirective ? (
+              <>
+                <span className="text-blue-600 dark:text-blue-400 font-semibold">
+                  {trimmed.split(":")[0]}:
+                </span>
+                <span>{trimmed.slice(trimmed.indexOf(":") + 1)}</span>
+              </>
+            ) : (
+              line || " "
+            )}
+          </div>
+        )
+      })}
+    </pre>
+  )
+}
+
+const InputFieldRobots = ({ query }: { query: string }) => {
+  const router = useRouter()
+  const initial = useMemo(() => initialQuery(query), [query])
+  const [value, setValue] = useState(initial)
+  const [body, setBody] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const hasFetched = useRef(false)
+
+  const fetchRobots = useCallback(async (url: string) => {
+    if (!url) {
+      setError(true)
+      return
+    }
+    try {
+      setLoading(true)
+      setError(false)
+      const res = await fetch(`/api/v1?q=${encodeURIComponent(url)}`)
+      const json = await res.json()
+
+      if (res.status === 429 || json.error === "Rate limit exceeded") {
+        const resetMs = json.reset
+        const hours =
+          typeof resetMs === "number"
+            ? Math.max(1, Math.ceil((resetMs - Date.now()) / 3_600_000))
+            : "?"
+        alert(`You reached the limit, try again in ${hours} hours or later`)
+        setError(true)
+        return
+      }
+
+      if (!res.ok || typeof json !== "string") {
+        setError(true)
+        setBody(null)
+        return
+      }
+
+      setBody(json)
+    } catch (err) {
+      console.error("Error fetching robots.txt:", err)
+      setError(true)
+      setBody(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (hasFetched.current) return
+    hasFetched.current = true
+    ;(async () => {
+      await fetchRobots(initial)
+      await logToolUsage(initial, "ROBOTS")
+    })()
+  }, [fetchRobots, initial])
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    await logToolUsage(value, "ROBOTS")
+    if (value === initial) {
+      await fetchRobots(value)
+      return
+    }
+    router.replace(`/robots?q=${encodeURIComponent(value)}`)
+  }
+
+  const handleCopy = async () => {
+    if (!body) return
+    await navigator.clipboard.writeText(body)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="w-full flex justify-center flex-col items-center px-4 md:px-0">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full md:w-[400px] flex justify-center my-6 items-center h-[60px] sticky top-4 rounded-lg"
+      >
+        <Input
+          onChange={(e) => setValue(e.target.value)}
+          value={value}
+          type="text"
+          autoFocus
+          placeholder="yoursite.com/robots.txt"
+          className="text-base h-[50px] dark:bg-white font-mono text-white dark:text-black bg-black"
+        />
+      </form>
+      <p className="text-sm text-muted-foreground -mt-6 mb-10">
+        example:{" "}
+        <Link href="https://freetoolsfr.com/robots.txt" target="_blank">
+          <span className="font-medium text-foreground">
+            https://freetoolsfr.com/robots.txt
+          </span>
+        </Link>
+      </p>
+
+      {loading ? (
+        <div className="w-full max-w-3xl space-y-3">
+          <div className="flex items-center gap-2 text-sm text-blue-600">
+            <Loader className="animate-spin h-4 w-4" />
+            Loading robots.txt…
+          </div>
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} className="h-5 w-full" />
+          ))}
+        </div>
+      ) : error || body === null ? (
+        <div className="px-3 flex items-center justify-center mt-4 w-full md:w-[400px] gap-4 py-3 bg-red-100 text-red-600 rounded-lg">
+          <p>
+            Could not load robots.txt from{" "}
+            <span className="underline font-medium">{value}</span>.
+          </p>
+        </div>
+      ) : (
+        <FadeIn className="w-full flex flex-col items-center gap-4">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleCopy}
+            className="gap-2"
+            disabled={!body}
+          >
+            {copied ? (
+              <Check className="h-4 w-4" />
+            ) : (
+              <Copy className="h-4 w-4" />
+            )}
+            {copied ? "Copied" : "Copy robots.txt"}
+          </Button>
+          {body.length === 0 ? (
+            <p className="text-sm text-muted-foreground font-mono">
+              robots.txt is empty (valid response).
+            </p>
+          ) : (
+            <HighlightedRobots text={body} />
+          )}
+        </FadeIn>
+      )}
+    </div>
+  )
+}
+
+export default InputFieldRobots

--- a/app/(tools)/robots/input-field.tsx
+++ b/app/(tools)/robots/input-field.tsx
@@ -4,7 +4,6 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { FadeIn } from "@/components/motion"
-import { logToolUsage } from "@/lib/log-tool-usage"
 import { Check, Copy, Loader } from "lucide-react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
@@ -65,7 +64,7 @@ const InputFieldRobots = ({ query }: { query: string }) => {
   const initial = useMemo(() => initialQuery(query), [query])
   const [value, setValue] = useState(initial)
   const [body, setBody] = useState<string | null>(null)
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
   const [copied, setCopied] = useState(false)
   const hasFetched = useRef(false)
@@ -78,7 +77,9 @@ const InputFieldRobots = ({ query }: { query: string }) => {
     try {
       setLoading(true)
       setError(false)
-      const res = await fetch(`/api/v1?q=${encodeURIComponent(url)}`)
+      const res = await fetch(
+        `/api/v1?q=${encodeURIComponent(url)}&tool=ROBOTS`
+      )
       const json = await res.json()
 
       if (res.status === 429 || json.error === "Rate limit exceeded") {
@@ -111,15 +112,11 @@ const InputFieldRobots = ({ query }: { query: string }) => {
   useEffect(() => {
     if (hasFetched.current) return
     hasFetched.current = true
-    ;(async () => {
-      await fetchRobots(initial)
-      await logToolUsage(initial, "ROBOTS")
-    })()
+    void fetchRobots(initial)
   }, [fetchRobots, initial])
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    await logToolUsage(value, "ROBOTS")
     if (value === initial) {
       await fetchRobots(value)
       return

--- a/app/(tools)/robots/input-field.tsx
+++ b/app/(tools)/robots/input-field.tsx
@@ -10,7 +10,7 @@ import Link from "next/link"
 import { useRouter } from "next/navigation"
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
-const DEFAULT_ROBOTS = "https://freetoolsfr.com/robots.txt"
+const DEFAULT_ROBOTS = "https://shrix1.com/robots.txt"
 
 const DIRECTIVE =
   /^(User-agent|Disallow|Allow|Sitemap|Crawl-delay|Host)\s*:/i
@@ -151,9 +151,9 @@ const InputFieldRobots = ({ query }: { query: string }) => {
       </form>
       <p className="text-sm text-muted-foreground -mt-6 mb-10">
         example:{" "}
-        <Link href="https://freetoolsfr.com/robots.txt" target="_blank">
+        <Link href="https://shrix1.com/robots.txt" target="_blank">
           <span className="font-medium text-foreground">
-            https://freetoolsfr.com/robots.txt
+            https://shrix1.com/robots.txt
           </span>
         </Link>
       </p>

--- a/app/(tools)/robots/page.tsx
+++ b/app/(tools)/robots/page.tsx
@@ -5,15 +5,35 @@ import { constructMetadata } from "@/lib/utils"
 import { FadeIn } from "@/components/motion"
 import { safeDecodeURIComponent } from "@/lib/safe-decode"
 import InputFieldRobots from "./input-field"
+import JsonLd from "@/components/json-ld"
+import ToolRelatedLinks from "@/components/tool-related-links"
+import { absoluteUrl, features } from "@/lib/site"
+
+const feature = features.robots
 
 export const metadata: Metadata = constructMetadata({
-  title: "Robots.txt Viewer | SeoCheckup",
-  description: "Inspect robots.txt directives, sitemaps, and crawl rules.",
-  canonical: "/robots",
+  title: "Free Robots.txt Checker | SeoCheckup",
+  description: feature.description,
+  canonical: feature.toolPath,
   ogImage: "/og-dark.png",
 })
 
 export const revalidate = 0
+
+const appJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: feature.appName,
+  url: absoluteUrl(feature.toolPath),
+  applicationCategory: "BusinessApplication",
+  operatingSystem: "Any",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+  description: feature.description,
+}
 
 export default async function RobotsPage({
   searchParams,
@@ -25,6 +45,7 @@ export default async function RobotsPage({
 
   return (
     <div className="min-h-screen max-h-full flex items-center flex-col pb-10 px-4 md:px-0">
+      <JsonLd data={appJsonLd} />
       <FadeIn>
         <section className="flex justify-center flex-col items-center gap-4 mt-3">
           <div
@@ -36,10 +57,14 @@ export default async function RobotsPage({
           <h2 className="text-center text-2xl font-semibold">
             Robots.txt Viewer
           </h2>
+          <p className="text-sm text-muted-foreground text-center max-w-md">
+            Inspect User-agent, Allow, Disallow, and Sitemap crawl rules.
+          </p>
         </section>
       </FadeIn>
 
       <InputFieldRobots key={query || "default"} query={query} />
+      <ToolRelatedLinks feature="robots" />
     </div>
   )
 }

--- a/app/(tools)/robots/page.tsx
+++ b/app/(tools)/robots/page.tsx
@@ -1,0 +1,45 @@
+import React from "react"
+import { Bot } from "lucide-react"
+import type { Metadata } from "next"
+import { constructMetadata } from "@/lib/utils"
+import { FadeIn } from "@/components/motion"
+import { safeDecodeURIComponent } from "@/lib/safe-decode"
+import InputFieldRobots from "./input-field"
+
+export const metadata: Metadata = constructMetadata({
+  title: "Robots.txt Viewer | SeoCheckup",
+  description: "Inspect robots.txt directives, sitemaps, and crawl rules.",
+  canonical: "/robots",
+  ogImage: "/og-dark.png",
+})
+
+export const revalidate = 0
+
+export default async function RobotsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>
+}) {
+  const { q } = await searchParams
+  const query = safeDecodeURIComponent(q)
+
+  return (
+    <div className="min-h-screen max-h-full flex items-center flex-col pb-10 px-4 md:px-0">
+      <FadeIn>
+        <section className="flex justify-center flex-col items-center gap-4 mt-3">
+          <div
+            className="w-11 h-11 flex justify-center items-center rounded-lg
+         bg-gradient-to-br from-secondary via-black/20 to-secondary/20 dark:from-primary/30 dark:via-primary/50 dark:to-primary text-black backdrop-blur-md"
+          >
+            <Bot />
+          </div>
+          <h2 className="text-center text-2xl font-semibold">
+            Robots.txt Viewer
+          </h2>
+        </section>
+      </FadeIn>
+
+      <InputFieldRobots key={query || "default"} query={query} />
+    </div>
+  )
+}

--- a/app/(tools)/sitemap/generate-deep-routes.tsx
+++ b/app/(tools)/sitemap/generate-deep-routes.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from "react"
+
 export function sortSitemapStructure(sitemap: any[]) {
   const isObject = (item: any) =>
     typeof item === "object" && item !== null && !Array.isArray(item)
@@ -79,12 +81,12 @@ export function SitemapToJSX({
 }: {
   sitemap: SitemapItem[]
   baseUrl: string
-}): JSX.Element {
+}): ReactElement {
   const createListItem = (
     item: SitemapItem,
     key?: string,
     isLeaf?: boolean
-  ): JSX.Element => {
+  ): ReactElement => {
     if (typeof item === "string") {
       return (
         <li

--- a/app/(tools)/sitemap/input-field.tsx
+++ b/app/(tools)/sitemap/input-field.tsx
@@ -1,207 +1,243 @@
-"use client";
-import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
-import { postDiscordLogs } from "@/lib/discord-webhook";
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import { FadeIn } from "@/components/motion"
+import { logToolUsage } from "@/lib/log-tool-usage"
 import {
   compareUrls,
   getSitemapBaseUrl,
   removeCommonPrefix,
-} from "@/lib/utils";
-import { Loader } from "lucide-react";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import React, { useEffect, useState } from "react";
+} from "@/lib/utils"
+import { Check, Copy, Loader } from "lucide-react"
+import { useRouter } from "next/navigation"
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   SitemapToJSX,
   restructureSitemap,
   sortSitemapStructure,
-} from "./generate-deep-routes";
+} from "./generate-deep-routes"
+
+const DEFAULT_SITEMAP = "https://freetoolsfr.com/sitemap.xml"
+
+function initialQuery(query: string) {
+  if (!query) return DEFAULT_SITEMAP
+  try {
+    return decodeURIComponent(query)
+  } catch {
+    return query
+  }
+}
 
 const InputField = ({ query }: { query: string }) => {
-  const router = useRouter();
-  const [value, setValue] = useState<string>("");
-  const [data, setData] = useState<string[]>([]);
-  const [baseUrl, setBaseUrl] = useState<string>("");
-  const [loading, setloading] = useState(false);
-  const [error, setError] = useState(false);
+  const router = useRouter()
+  const initial = useMemo(() => initialQuery(query), [query])
+  const [value, setValue] = useState(initial)
+  const [data, setData] = useState<string[]>([])
+  const [rawUrls, setRawUrls] = useState<string[]>([])
+  const [baseUrl, setBaseUrl] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const [resultsReady, setResultsReady] = useState(false)
   const [sitemapWithDeepRoutes, setSitemapWithDeepRoutes] = useState<
-    Array<string | { [key: string]: string | any[] }>
-  >([]);
+    ReturnType<typeof restructureSitemap>
+  >([])
+  const hasFetched = useRef(false)
 
-  useEffect(() => {
-    const q = decodeURIComponent(query);
-    setValue(q || "https://freetoolsfr.com/sitemap.xml");
-  }, [query]);
-
-  useEffect(() => {
-    if (value) {
-      router.push(`/sitemap?q=${encodeURIComponent(value)}`);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value]);
-
-  useEffect(() => {
-    (async () => {
-      const { baseUrl: base, urls, sitemapWithDeepRoutes } = await getUrls();
-      setSitemapWithDeepRoutes(sitemapWithDeepRoutes);
-      setBaseUrl(base);
-      setData(urls);
-    })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  async function getUrls(): Promise<{
-    baseUrl: string;
-    urls: string[];
-    sitemapWithDeepRoutes: Array<string | { [key: string]: string | any[] }>;
-  }> {
+  const fetchSitemapUrl = useCallback(async (url: string): Promise<string[]> => {
     try {
-      setloading(true);
-      const data = await fetchSitemapUrl(query);
-      const sitemapWithDeepRoutes = restructureSitemap(data);
-      const sortedSitemapDeepRoutes = sortSitemapStructure(
-        sitemapWithDeepRoutes
-      );
-      const sortedUrls = data.sort(compareUrls);
-      const baseUrl = getSitemapBaseUrl(query);
-      const modifiedUrls = sortedUrls.map((url) =>
-        removeCommonPrefix(url, baseUrl)
-      );
-      setError(false);
-      setloading(false);
-      return {
-        baseUrl,
-        urls: modifiedUrls,
-        sitemapWithDeepRoutes: sortedSitemapDeepRoutes,
-      };
-    } catch (e) {
-      setloading(false);
-      setError(true);
-      return { baseUrl: "", urls: [], sitemapWithDeepRoutes: [] };
-    }
-  }
+      const res = await fetch(`/api/v1?q=${encodeURIComponent(url)}`)
+      const xmlData = await res.json()
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const { baseUrl: base, urls, sitemapWithDeepRoutes } = await getUrls();
-    await postDiscordLogs(decodeURIComponent(query), "SITEMAP");
-    if (urls.length === 0) {
-      setError(true);
-    }
-    setSitemapWithDeepRoutes(sitemapWithDeepRoutes);
-    setBaseUrl(base);
-    setData(urls);
-  };
-
-  async function fetchSitemapUrl(url: string): Promise<string[]> {
-    try {
-      const data: any = await fetch(`/api/v1?q=${url}`);
-      const xmlData = await data.json();
-
-      if (xmlData.error === "Rate limit exceeded") {
-        alert(
-          "You reached the limit, try again in " +
-          xmlData.data.reset +
-          " hours or try again later"
-        );
-        return [];
+      if (res.status === 429 || xmlData.error === "Rate limit exceeded") {
+        const resetMs = xmlData.reset ?? xmlData.data?.reset
+        const hours =
+          typeof resetMs === "number"
+            ? Math.max(1, Math.ceil((resetMs - Date.now()) / 3_600_000))
+            : "?"
+        alert(`You reached the limit, try again in ${hours} hours or later`)
+        return []
       }
 
-      let locValues: string[] = [];
-      const parser = new DOMParser();
-      const xmlDoc = parser.parseFromString(xmlData, "application/xml");
-      const locNodes = xmlDoc.querySelectorAll("loc");
+      if (!res.ok || typeof xmlData !== "string") {
+        return []
+      }
+
+      const locValues: string[] = []
+      const parser = new DOMParser()
+      const xmlDoc = parser.parseFromString(xmlData, "application/xml")
+      const locNodes = xmlDoc.querySelectorAll("loc")
       locNodes.forEach((locNode) => {
-        locValues.push(locNode.textContent as string);
-      });
-      return locValues;
-    } catch (error: any) {
-      setError(true);
-      console.error("Error fetching or parsing XML:", error.message);
-      return [];
+        if (locNode.textContent) locValues.push(locNode.textContent)
+      })
+      return locValues
+    } catch (err) {
+      console.error("Error fetching or parsing XML:", err)
+      return []
     }
+  }, [])
+
+  const getUrls = useCallback(
+    async (target: string) => {
+      if (!target) {
+        setError(true)
+        return {
+          baseUrl: "",
+          urls: [],
+          raw: [],
+          sitemapWithDeepRoutes: [] as ReturnType<typeof restructureSitemap>,
+        }
+      }
+      try {
+        setLoading(true)
+        setResultsReady(false)
+        const fetched = await fetchSitemapUrl(target)
+        const deep = sortSitemapStructure(restructureSitemap(fetched))
+        const sortedUrls = [...fetched].sort(compareUrls)
+        const base = getSitemapBaseUrl(target)
+        const modifiedUrls = sortedUrls.map((url) =>
+          removeCommonPrefix(url, base)
+        )
+        setError(fetched.length === 0)
+        setLoading(false)
+        return {
+          baseUrl: base,
+          urls: modifiedUrls,
+          raw: sortedUrls,
+          sitemapWithDeepRoutes: deep,
+        }
+      } catch {
+        setLoading(false)
+        setError(true)
+        return {
+          baseUrl: "",
+          urls: [],
+          raw: [],
+          sitemapWithDeepRoutes: [],
+        }
+      }
+    },
+    [fetchSitemapUrl]
+  )
+
+  useEffect(() => {
+    if (hasFetched.current) return
+    hasFetched.current = true
+    ;(async () => {
+      const result = await getUrls(initial)
+      setSitemapWithDeepRoutes(result.sitemapWithDeepRoutes)
+      setBaseUrl(result.baseUrl)
+      setData(result.urls)
+      setRawUrls(result.raw)
+      setResultsReady(result.urls.length > 0)
+    })()
+  }, [getUrls, initial])
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    await logToolUsage(value, "SITEMAP")
+    // Same query: key won't remount — fetch in place. Different query: navigate remounts.
+    if (value === initial) {
+      const result = await getUrls(value)
+      setSitemapWithDeepRoutes(result.sitemapWithDeepRoutes)
+      setBaseUrl(result.baseUrl)
+      setData(result.urls)
+      setRawUrls(result.raw)
+      setResultsReady(result.urls.length > 0)
+      return
+    }
+    router.replace(`/sitemap?q=${encodeURIComponent(value)}`)
+  }
+
+  const handleCopy = async () => {
+    if (!rawUrls.length) return
+    await navigator.clipboard.writeText(rawUrls.join("\n"))
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
   }
 
   return (
-    <>
-      <div className="w-full flex justify-center flex-col items-center px-4 md:px-0">
-        <form
-          onSubmit={handleSubmit}
-          className="w-full md:w-[400px] flex justify-center my-6 items-center h-[60px] sticky top-4 rounded-lg"
-        >
-          <Input
-            onChange={(e) => setValue(e.target.value)}
-            value={value}
-            type="text"
-            autoFocus
-            placeholder="yoursite.com/sitemap.xml"
-            className="text-base h-[50px] dark:bg-white font-mono text-white dark:text-black bg-black"
-          />
-        </form>
-        <p className="text-sm text-gray-500 -mt-6 mb-10">
-          Ensure your{" "}
-          <span className="font-medium text-black dark:text-white">
-            sitemap.xml
-          </span>{" "}
-          URL is correct before using it.
-        </p>
-        <section className="flex gap-4 items-center">
-          {loading ? (
-            <></>
-          ) : (
-            data.length !== 0 && (
-              <div className="flex flex-col md:flex-row gap-4 items-center">
-                <Badge className="underline font-medium font-mono text-base underline-offset-2">
-                  {baseUrl}
-                </Badge>
+    <div className="w-full flex justify-center flex-col items-center px-4 md:px-0">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full md:w-[400px] flex justify-center my-6 items-center h-[60px] sticky top-4 rounded-lg"
+      >
+        <Input
+          onChange={(e) => setValue(e.target.value)}
+          value={value}
+          type="text"
+          autoFocus
+          placeholder="yoursite.com/sitemap.xml"
+          className="text-base h-[50px] dark:bg-white font-mono text-white dark:text-black bg-black"
+        />
+      </form>
+      <p className="text-sm text-muted-foreground -mt-6 mb-10">
+        Ensure your{" "}
+        <span className="font-medium text-foreground">sitemap.xml</span> URL is
+        correct before using it.
+      </p>
 
-                <span>
-                  Number of Links
-                  <Badge className="underline ml-2 font-medium font-mono text-base underline-offset-2">
-                    {data.length}
-                  </Badge>
-                </span>
-              </div>
-            )
-          )}
-        </section>
-
-        {loading ? (
-          <div className="px-5 text-lg py-2 bg-blue-50 text-blue-600 flex justify-center rounded-lg items-center gap-3">
-            <Loader className="animate-spin" />
-            Loading
+      {loading ? (
+        <div className="w-full max-w-5xl space-y-3">
+          <div className="flex items-center gap-2 text-sm text-blue-600">
+            <Loader className="animate-spin h-4 w-4" />
+            Parsing sitemap…
           </div>
-        ) : data.length === 0 || error ? (
-          <>
-            <div className="px-3 flex items-center justify-center mt-4 w-full md:w-[400px] gap-4 py-3 bg-red-100 text-red-600 rounded-lg">
-              <p>
-                {" "}
-                Its seems like the sitemap url:{" "}
-                <span className="underline font-medium">{value}</span> is not
-                exist or Try Refreshing.
-              </p>
-            </div>
-          </>
-        ) : (
-          <>
-            <div className="flex flex-wrap gap-3 max-w-5xl mt-8">
-              {/* {data.map((url, idx) => (
-                <Link
-                  key={url + idx}
-                  href={`${baseUrl}${url}`}
-                  target="_blank"
-                  className="text-base hover:underline underline-offset-2 dark:hover:bg-gray-100/20 hover:bg-gray-200 hover:dark:text-white px-2 py-1 rounded-lg"
-                >
-                  <p>{url}</p>
-                </Link>
-              ))} */}
-              <SitemapToJSX sitemap={sitemapWithDeepRoutes} baseUrl={baseUrl} />
-            </div>
-          </>
-        )}
-      </div>
-    </>
-  );
-};
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-8 w-full max-w-md" />
+          ))}
+        </div>
+      ) : data.length === 0 || error ? (
+        <div className="px-3 flex items-center justify-center mt-4 w-full md:w-[400px] gap-4 py-3 bg-red-100 text-red-600 rounded-lg">
+          <p>
+            It seems like the sitemap url:{" "}
+            <span className="underline font-medium">{value}</span> does not
+            exist or try refreshing.
+          </p>
+        </div>
+      ) : (
+        <FadeIn className="w-full max-w-5xl flex flex-col items-center">
+          <section className="flex flex-col md:flex-row gap-3 items-center mb-6">
+            <Badge className="underline font-medium font-mono text-base underline-offset-2">
+              {baseUrl}
+            </Badge>
+            <span className="text-sm">
+              {data.length} URL{data.length === 1 ? "" : "s"} found
+              <Badge className="ml-2 font-medium font-mono text-base">
+                {data.length}
+              </Badge>
+            </span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleCopy}
+              className="gap-2"
+            >
+              {copied ? (
+                <Check className="h-4 w-4" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+              {copied ? "Copied" : "Copy all URLs"}
+            </Button>
+          </section>
 
-export default InputField;
+          {resultsReady && (
+            <div className="flex flex-wrap gap-3 max-w-5xl">
+              <SitemapToJSX
+                sitemap={sitemapWithDeepRoutes}
+                baseUrl={baseUrl}
+              />
+            </div>
+          )}
+        </FadeIn>
+      )}
+    </div>
+  )
+}
+
+export default InputField

--- a/app/(tools)/sitemap/input-field.tsx
+++ b/app/(tools)/sitemap/input-field.tsx
@@ -12,15 +12,6 @@ import {
   removeCommonPrefix,
 } from "@/lib/utils"
 import { Check, Copy, Loader } from "lucide-react"
-
-type ExpandMeta = {
-  rootKind: "urlset" | "sitemapindex" | "unknown"
-  childSitemapsFetched: number
-  childSitemapsFailed: { url: string; reason: string }[]
-  truncated: boolean
-}
-
-type ExpandResult = ExpandMeta & { urls: string[] }
 import { useRouter } from "next/navigation"
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
@@ -31,6 +22,23 @@ import {
 
 const DEFAULT_SITEMAP = "https://supwriter.com/sitemap.xml"
 
+type SitemapSource = {
+  sitemapUrl: string
+  urlCount: number
+  urls: string[]
+  error?: string
+}
+
+type ExpandResult = {
+  indexUrl: string
+  urls: string[]
+  rootKind: "urlset" | "sitemapindex" | "unknown"
+  sources: SitemapSource[]
+  childSitemapsFetched: number
+  childSitemapsFailed: { url: string; reason: string }[]
+  truncated: boolean
+}
+
 function initialQuery(query: string) {
   if (!query) return DEFAULT_SITEMAP
   try {
@@ -38,6 +46,23 @@ function initialQuery(query: string) {
   } catch {
     return query
   }
+}
+
+function sourceLabel(sitemapUrl: string): string {
+  try {
+    const pathname = new URL(sitemapUrl).pathname
+    const file = pathname.split("/").filter(Boolean).pop()
+    return file || pathname || sitemapUrl
+  } catch {
+    return sitemapUrl
+  }
+}
+
+function buildView(urls: string[], base: string) {
+  const sortedUrls = [...urls].sort(compareUrls)
+  const modifiedUrls = sortedUrls.map((url) => removeCommonPrefix(url, base))
+  const deep = sortSitemapStructure(restructureSitemap(sortedUrls))
+  return { modifiedUrls, sortedUrls, deep }
 }
 
 const InputField = ({ query }: { query: string }) => {
@@ -51,11 +76,28 @@ const InputField = ({ query }: { query: string }) => {
   const [error, setError] = useState(false)
   const [copied, setCopied] = useState(false)
   const [resultsReady, setResultsReady] = useState(false)
-  const [expandMeta, setExpandMeta] = useState<ExpandMeta | null>(null)
+  const [expandResult, setExpandResult] = useState<ExpandResult | null>(null)
+  const [selectedSource, setSelectedSource] = useState<string>("all")
   const [sitemapWithDeepRoutes, setSitemapWithDeepRoutes] = useState<
     ReturnType<typeof restructureSitemap>
   >([])
   const hasFetched = useRef(false)
+
+  const applySourceFilter = useCallback(
+    (expanded: ExpandResult, sourceKey: string, base: string) => {
+      const urls =
+        sourceKey === "all"
+          ? expanded.urls
+          : (expanded.sources.find((s) => s.sitemapUrl === sourceKey)?.urls ??
+            [])
+      const view = buildView(urls, base)
+      setData(view.modifiedUrls)
+      setRawUrls(view.sortedUrls)
+      setSitemapWithDeepRoutes(view.deep)
+      setResultsReady(view.sortedUrls.length > 0 || sourceKey !== "all")
+    },
+    []
+  )
 
   const fetchExpandedSitemap = useCallback(
     async (url: string): Promise<ExpandResult | null> => {
@@ -73,7 +115,7 @@ const InputField = ({ query }: { query: string }) => {
           return null
         }
 
-        if (!res.ok || !Array.isArray(json.urls)) {
+        if (!res.ok || !Array.isArray(json.urls) || !Array.isArray(json.sources)) {
           return null
         }
 
@@ -90,13 +132,7 @@ const InputField = ({ query }: { query: string }) => {
     async (target: string) => {
       if (!target) {
         setError(true)
-        return {
-          baseUrl: "",
-          urls: [],
-          raw: [],
-          sitemapWithDeepRoutes: [] as ReturnType<typeof restructureSitemap>,
-          meta: null,
-        }
+        return null
       }
       try {
         setLoading(true)
@@ -105,81 +141,48 @@ const InputField = ({ query }: { query: string }) => {
         if (!expanded) {
           setError(true)
           setLoading(false)
-          setExpandMeta(null)
-          return {
-            baseUrl: "",
-            urls: [],
-            raw: [],
-            sitemapWithDeepRoutes: [],
-            meta: null,
-          }
+          setExpandResult(null)
+          return null
         }
 
-        const fetched = expanded.urls
-        const deep = sortSitemapStructure(restructureSitemap(fetched))
-        const sortedUrls = [...fetched].sort(compareUrls)
         const base = getSitemapBaseUrl(target)
-        const modifiedUrls = sortedUrls.map((url) =>
-          removeCommonPrefix(url, base)
-        )
-        const meta = {
-          rootKind: expanded.rootKind,
-          childSitemapsFetched: expanded.childSitemapsFetched,
-          childSitemapsFailed: expanded.childSitemapsFailed,
-          truncated: expanded.truncated,
-        }
-        setError(fetched.length === 0)
+        setBaseUrl(base)
+        setExpandResult(expanded)
+        setSelectedSource("all")
+        applySourceFilter(expanded, "all", base)
+        setError(expanded.urls.length === 0)
         setLoading(false)
-        setExpandMeta(meta)
-        return {
-          baseUrl: base,
-          urls: modifiedUrls,
-          raw: sortedUrls,
-          sitemapWithDeepRoutes: deep,
-          meta,
-        }
+        return expanded
       } catch {
         setLoading(false)
         setError(true)
-        setExpandMeta(null)
-        return {
-          baseUrl: "",
-          urls: [],
-          raw: [],
-          sitemapWithDeepRoutes: [],
-          meta: null,
-        }
+        setExpandResult(null)
+        return null
       }
     },
-    [fetchExpandedSitemap]
+    [applySourceFilter, fetchExpandedSitemap]
   )
 
   useEffect(() => {
     if (hasFetched.current) return
     hasFetched.current = true
-    ;(async () => {
-      const result = await getUrls(initial)
-      setSitemapWithDeepRoutes(result.sitemapWithDeepRoutes)
-      setBaseUrl(result.baseUrl)
-      setData(result.urls)
-      setRawUrls(result.raw)
-      setResultsReady(result.urls.length > 0)
-    })()
+    void getUrls(initial)
   }, [getUrls, initial])
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     await logToolUsage(value, "SITEMAP")
     if (value === initial) {
-      const result = await getUrls(value)
-      setSitemapWithDeepRoutes(result.sitemapWithDeepRoutes)
-      setBaseUrl(result.baseUrl)
-      setData(result.urls)
-      setRawUrls(result.raw)
-      setResultsReady(result.urls.length > 0)
+      await getUrls(value)
       return
     }
     router.replace(`/sitemap?q=${encodeURIComponent(value)}`)
+  }
+
+  const handleSourceChange = (sourceKey: string) => {
+    setSelectedSource(sourceKey)
+    if (!expandResult) return
+    applySourceFilter(expandResult, sourceKey, baseUrl)
   }
 
   const handleCopy = async () => {
@@ -188,6 +191,20 @@ const InputField = ({ query }: { query: string }) => {
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
   }
+
+  const showSourceFilter =
+    expandResult?.rootKind === "sitemapindex" &&
+    expandResult.sources.length > 0
+
+  const selectedSourceUrl =
+    selectedSource === "all"
+      ? expandResult?.indexUrl
+      : selectedSource
+
+  const selectedSourceMeta =
+    selectedSource === "all"
+      ? null
+      : expandResult?.sources.find((s) => s.sitemapUrl === selectedSource)
 
   return (
     <div className="w-full flex justify-center flex-col items-center px-4 md:px-0">
@@ -220,7 +237,7 @@ const InputField = ({ query }: { query: string }) => {
             <Skeleton key={i} className="h-8 w-full" />
           ))}
         </div>
-      ) : data.length === 0 || error ? (
+      ) : error || !expandResult || expandResult.urls.length === 0 ? (
         <div className="px-3 flex items-center justify-center mt-4 w-full md:w-[400px] gap-4 py-3 bg-red-100 text-red-600 rounded-lg">
           <p>
             It seems like the sitemap url:{" "}
@@ -235,10 +252,10 @@ const InputField = ({ query }: { query: string }) => {
               {baseUrl}
             </Badge>
             <span className="text-sm">
-              {data.length.toLocaleString()} URL
-              {data.length === 1 ? "" : "s"} found
+              {rawUrls.length.toLocaleString()} URL
+              {rawUrls.length === 1 ? "" : "s"} found
               <Badge className="ml-2 font-medium font-mono text-base">
-                {data.length.toLocaleString()}
+                {rawUrls.length.toLocaleString()}
               </Badge>
             </span>
             <Button
@@ -247,29 +264,102 @@ const InputField = ({ query }: { query: string }) => {
               size="sm"
               onClick={handleCopy}
               className="gap-2"
+              disabled={!rawUrls.length}
             >
               {copied ? (
                 <Check className="h-4 w-4" />
               ) : (
                 <Copy className="h-4 w-4" />
               )}
-              {copied ? "Copied" : "Copy all URLs"}
+              {copied ? "Copied" : "Copy URLs"}
             </Button>
           </section>
 
-          {expandMeta && (
-            <p className="text-sm text-muted-foreground mb-6 text-center">
-              {expandMeta.rootKind === "sitemapindex"
-                ? `Expanded ${expandMeta.childSitemapsFetched} child sitemap${expandMeta.childSitemapsFetched === 1 ? "" : "s"}`
-                : "Parsed urlset sitemap"}
-              {expandMeta.childSitemapsFailed.length > 0
-                ? ` · ${expandMeta.childSitemapsFailed.length} failed`
-                : ""}
-              {expandMeta.truncated ? " · truncated at limit" : ""}
-            </p>
+          {expandResult && (
+            <div className="w-full max-w-xl flex flex-col items-center gap-3 mb-6 px-2">
+              <p className="text-sm text-muted-foreground text-center break-all">
+                <span className="font-medium text-foreground">
+                  {expandResult.rootKind === "sitemapindex"
+                    ? "Index:"
+                    : "Sitemap:"}
+                </span>{" "}
+                <a
+                  href={expandResult.indexUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-mono underline underline-offset-2 hover:text-foreground"
+                >
+                  {expandResult.indexUrl}
+                </a>
+              </p>
+
+              {showSourceFilter && (
+                <>
+                  <label className="w-full flex flex-col gap-1.5 text-sm">
+                    <span className="text-muted-foreground text-center">
+                      Filter by child sitemap
+                    </span>
+                    <select
+                      value={selectedSource}
+                      onChange={(e) => handleSourceChange(e.target.value)}
+                      className="w-full h-10 rounded-md border border-input bg-background px-3 py-2 text-sm font-mono shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      <option value="all">
+                        All sitemaps ({expandResult.urls.length.toLocaleString()}
+                        )
+                      </option>
+                      {expandResult.sources.map((source) => (
+                        <option
+                          key={source.sitemapUrl}
+                          value={source.sitemapUrl}
+                          title={source.sitemapUrl}
+                        >
+                          {sourceLabel(source.sitemapUrl)} (
+                          {source.error
+                            ? "failed"
+                            : source.urlCount.toLocaleString()}
+                          )
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  {selectedSourceUrl && (
+                    <p className="text-xs text-muted-foreground text-center break-all">
+                      <span className="font-medium text-foreground">
+                        {selectedSource === "all" ? "Showing:" : "Source:"}
+                      </span>{" "}
+                      <a
+                        href={selectedSourceUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-mono underline underline-offset-2 hover:text-foreground"
+                      >
+                        {selectedSourceUrl}
+                      </a>
+                      {selectedSourceMeta?.error
+                        ? ` — ${selectedSourceMeta.error}`
+                        : ""}
+                    </p>
+                  )}
+                </>
+              )}
+
+              {(expandResult.truncated ||
+                expandResult.childSitemapsFailed.length > 0) && (
+                <p className="text-xs text-muted-foreground text-center">
+                  {expandResult.childSitemapsFailed.length > 0
+                    ? `${expandResult.childSitemapsFailed.length} child sitemap(s) failed`
+                    : ""}
+                  {expandResult.truncated
+                    ? `${expandResult.childSitemapsFailed.length > 0 ? " · " : ""}truncated at limit`
+                    : ""}
+                </p>
+              )}
+            </div>
           )}
 
-          {resultsReady && (
+          {resultsReady && rawUrls.length > 0 && (
             <div className="flex flex-wrap gap-3 max-w-5xl">
               <SitemapToJSX
                 sitemap={sitemapWithDeepRoutes}
@@ -277,6 +367,15 @@ const InputField = ({ query }: { query: string }) => {
               />
             </div>
           )}
+
+          {resultsReady &&
+            rawUrls.length === 0 &&
+            selectedSource !== "all" &&
+            selectedSourceMeta?.error && (
+              <p className="text-sm text-red-600 text-center">
+                Could not load this child sitemap.
+              </p>
+            )}
         </FadeIn>
       )}
     </div>

--- a/app/(tools)/sitemap/input-field.tsx
+++ b/app/(tools)/sitemap/input-field.tsx
@@ -5,7 +5,6 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { FadeIn } from "@/components/motion"
-import { logToolUsage } from "@/lib/log-tool-usage"
 import {
   compareUrls,
   getSitemapBaseUrl,
@@ -171,7 +170,6 @@ const InputField = ({ query }: { query: string }) => {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    await logToolUsage(value, "SITEMAP")
     if (value === initial) {
       await getUrls(value)
       return

--- a/app/(tools)/sitemap/input-field.tsx
+++ b/app/(tools)/sitemap/input-field.tsx
@@ -12,6 +12,15 @@ import {
   removeCommonPrefix,
 } from "@/lib/utils"
 import { Check, Copy, Loader } from "lucide-react"
+
+type ExpandMeta = {
+  rootKind: "urlset" | "sitemapindex" | "unknown"
+  childSitemapsFetched: number
+  childSitemapsFailed: { url: string; reason: string }[]
+  truncated: boolean
+}
+
+type ExpandResult = ExpandMeta & { urls: string[] }
 import { useRouter } from "next/navigation"
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
@@ -20,7 +29,7 @@ import {
   sortSitemapStructure,
 } from "./generate-deep-routes"
 
-const DEFAULT_SITEMAP = "https://freetoolsfr.com/sitemap.xml"
+const DEFAULT_SITEMAP = "https://supwriter.com/sitemap.xml"
 
 function initialQuery(query: string) {
   if (!query) return DEFAULT_SITEMAP
@@ -42,43 +51,40 @@ const InputField = ({ query }: { query: string }) => {
   const [error, setError] = useState(false)
   const [copied, setCopied] = useState(false)
   const [resultsReady, setResultsReady] = useState(false)
+  const [expandMeta, setExpandMeta] = useState<ExpandMeta | null>(null)
   const [sitemapWithDeepRoutes, setSitemapWithDeepRoutes] = useState<
     ReturnType<typeof restructureSitemap>
   >([])
   const hasFetched = useRef(false)
 
-  const fetchSitemapUrl = useCallback(async (url: string): Promise<string[]> => {
-    try {
-      const res = await fetch(`/api/v1?q=${encodeURIComponent(url)}`)
-      const xmlData = await res.json()
+  const fetchExpandedSitemap = useCallback(
+    async (url: string): Promise<ExpandResult | null> => {
+      try {
+        const res = await fetch(`/api/sitemap?q=${encodeURIComponent(url)}`)
+        const json = await res.json()
 
-      if (res.status === 429 || xmlData.error === "Rate limit exceeded") {
-        const resetMs = xmlData.reset ?? xmlData.data?.reset
-        const hours =
-          typeof resetMs === "number"
-            ? Math.max(1, Math.ceil((resetMs - Date.now()) / 3_600_000))
-            : "?"
-        alert(`You reached the limit, try again in ${hours} hours or later`)
-        return []
+        if (res.status === 429 || json.error === "Rate limit exceeded") {
+          const resetMs = json.reset ?? json.data?.reset
+          const hours =
+            typeof resetMs === "number"
+              ? Math.max(1, Math.ceil((resetMs - Date.now()) / 3_600_000))
+              : "?"
+          alert(`You reached the limit, try again in ${hours} hours or later`)
+          return null
+        }
+
+        if (!res.ok || !Array.isArray(json.urls)) {
+          return null
+        }
+
+        return json as ExpandResult
+      } catch (err) {
+        console.error("Error fetching expanded sitemap:", err)
+        return null
       }
-
-      if (!res.ok || typeof xmlData !== "string") {
-        return []
-      }
-
-      const locValues: string[] = []
-      const parser = new DOMParser()
-      const xmlDoc = parser.parseFromString(xmlData, "application/xml")
-      const locNodes = xmlDoc.querySelectorAll("loc")
-      locNodes.forEach((locNode) => {
-        if (locNode.textContent) locValues.push(locNode.textContent)
-      })
-      return locValues
-    } catch (err) {
-      console.error("Error fetching or parsing XML:", err)
-      return []
-    }
-  }, [])
+    },
+    []
+  )
 
   const getUrls = useCallback(
     async (target: string) => {
@@ -89,38 +95,63 @@ const InputField = ({ query }: { query: string }) => {
           urls: [],
           raw: [],
           sitemapWithDeepRoutes: [] as ReturnType<typeof restructureSitemap>,
+          meta: null,
         }
       }
       try {
         setLoading(true)
         setResultsReady(false)
-        const fetched = await fetchSitemapUrl(target)
+        const expanded = await fetchExpandedSitemap(target)
+        if (!expanded) {
+          setError(true)
+          setLoading(false)
+          setExpandMeta(null)
+          return {
+            baseUrl: "",
+            urls: [],
+            raw: [],
+            sitemapWithDeepRoutes: [],
+            meta: null,
+          }
+        }
+
+        const fetched = expanded.urls
         const deep = sortSitemapStructure(restructureSitemap(fetched))
         const sortedUrls = [...fetched].sort(compareUrls)
         const base = getSitemapBaseUrl(target)
         const modifiedUrls = sortedUrls.map((url) =>
           removeCommonPrefix(url, base)
         )
+        const meta = {
+          rootKind: expanded.rootKind,
+          childSitemapsFetched: expanded.childSitemapsFetched,
+          childSitemapsFailed: expanded.childSitemapsFailed,
+          truncated: expanded.truncated,
+        }
         setError(fetched.length === 0)
         setLoading(false)
+        setExpandMeta(meta)
         return {
           baseUrl: base,
           urls: modifiedUrls,
           raw: sortedUrls,
           sitemapWithDeepRoutes: deep,
+          meta,
         }
       } catch {
         setLoading(false)
         setError(true)
+        setExpandMeta(null)
         return {
           baseUrl: "",
           urls: [],
           raw: [],
           sitemapWithDeepRoutes: [],
+          meta: null,
         }
       }
     },
-    [fetchSitemapUrl]
+    [fetchExpandedSitemap]
   )
 
   useEffect(() => {
@@ -139,7 +170,6 @@ const InputField = ({ query }: { query: string }) => {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     await logToolUsage(value, "SITEMAP")
-    // Same query: key won't remount — fetch in place. Different query: navigate remounts.
     if (value === initial) {
       const result = await getUrls(value)
       setSitemapWithDeepRoutes(result.sitemapWithDeepRoutes)
@@ -177,17 +207,17 @@ const InputField = ({ query }: { query: string }) => {
       <p className="text-sm text-muted-foreground -mt-6 mb-10">
         Ensure your{" "}
         <span className="font-medium text-foreground">sitemap.xml</span> URL is
-        correct before using it.
+        correct before using it. Sitemap indexes are expanded automatically.
       </p>
 
       {loading ? (
-        <div className="w-full max-w-5xl space-y-3">
+        <div className="w-full max-w-md mx-auto flex flex-col items-center gap-3">
           <div className="flex items-center gap-2 text-sm text-blue-600">
             <Loader className="animate-spin h-4 w-4" />
-            Parsing sitemap…
+            Expanding sitemap…
           </div>
           {Array.from({ length: 6 }).map((_, i) => (
-            <Skeleton key={i} className="h-8 w-full max-w-md" />
+            <Skeleton key={i} className="h-8 w-full" />
           ))}
         </div>
       ) : data.length === 0 || error ? (
@@ -200,14 +230,15 @@ const InputField = ({ query }: { query: string }) => {
         </div>
       ) : (
         <FadeIn className="w-full max-w-5xl flex flex-col items-center">
-          <section className="flex flex-col md:flex-row gap-3 items-center mb-6">
+          <section className="flex flex-col md:flex-row gap-3 items-center mb-3 flex-wrap justify-center">
             <Badge className="underline font-medium font-mono text-base underline-offset-2">
               {baseUrl}
             </Badge>
             <span className="text-sm">
-              {data.length} URL{data.length === 1 ? "" : "s"} found
+              {data.length.toLocaleString()} URL
+              {data.length === 1 ? "" : "s"} found
               <Badge className="ml-2 font-medium font-mono text-base">
-                {data.length}
+                {data.length.toLocaleString()}
               </Badge>
             </span>
             <Button
@@ -225,6 +256,18 @@ const InputField = ({ query }: { query: string }) => {
               {copied ? "Copied" : "Copy all URLs"}
             </Button>
           </section>
+
+          {expandMeta && (
+            <p className="text-sm text-muted-foreground mb-6 text-center">
+              {expandMeta.rootKind === "sitemapindex"
+                ? `Expanded ${expandMeta.childSitemapsFetched} child sitemap${expandMeta.childSitemapsFetched === 1 ? "" : "s"}`
+                : "Parsed urlset sitemap"}
+              {expandMeta.childSitemapsFailed.length > 0
+                ? ` · ${expandMeta.childSitemapsFailed.length} failed`
+                : ""}
+              {expandMeta.truncated ? " · truncated at limit" : ""}
+            </p>
+          )}
 
           {resultsReady && (
             <div className="flex flex-wrap gap-3 max-w-5xl">

--- a/app/(tools)/sitemap/input-field.tsx
+++ b/app/(tools)/sitemap/input-field.tsx
@@ -20,7 +20,7 @@ import {
   sortSitemapStructure,
 } from "./generate-deep-routes"
 
-const DEFAULT_SITEMAP = "https://supwriter.com/sitemap.xml"
+const DEFAULT_SITEMAP = "https://shrix1.com/sitemap.xml"
 
 type SitemapSource = {
   sitemapUrl: string

--- a/app/(tools)/sitemap/page.tsx
+++ b/app/(tools)/sitemap/page.tsx
@@ -5,15 +5,35 @@ import type { Metadata } from "next"
 import { constructMetadata } from "@/lib/utils"
 import { FadeIn } from "@/components/motion"
 import { safeDecodeURIComponent } from "@/lib/safe-decode"
+import JsonLd from "@/components/json-ld"
+import ToolRelatedLinks from "@/components/tool-related-links"
+import { absoluteUrl, features } from "@/lib/site"
+
+const feature = features.sitemap
 
 export const metadata: Metadata = constructMetadata({
-  title: "Sitemap Link Checker | SeoCheckup",
-  description: "Easily review your sitemap by adding yoursite.com/sitemap.xml.",
-  canonical: "/sitemap",
+  title: "Free XML Sitemap Checker | SeoCheckup",
+  description: feature.description,
+  canonical: feature.toolPath,
   ogImage: "/og-dark.png",
 })
 
 export const revalidate = 0
+
+const appJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: feature.appName,
+  url: absoluteUrl(feature.toolPath),
+  applicationCategory: "BusinessApplication",
+  operatingSystem: "Any",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+  description: feature.description,
+}
 
 export default async function Sitemap({
   searchParams,
@@ -25,6 +45,7 @@ export default async function Sitemap({
 
   return (
     <div className="min-h-screen max-h-full flex items-center flex-col pb-10">
+      <JsonLd data={appJsonLd} />
       <FadeIn>
         <section className="flex justify-center flex-col items-center gap-4 mt-3">
           <div
@@ -36,10 +57,14 @@ export default async function Sitemap({
           <h2 className="text-center text-2xl font-semibold">
             Sitemap Link Checker
           </h2>
+          <p className="text-sm text-muted-foreground text-center max-w-md px-4">
+            Expand sitemap indexes, list every URL, then copy or filter results.
+          </p>
         </section>
       </FadeIn>
 
       <InputField key={query || "default"} query={query} />
+      <ToolRelatedLinks feature="sitemap" />
     </div>
   )
 }

--- a/app/(tools)/sitemap/page.tsx
+++ b/app/(tools)/sitemap/page.tsx
@@ -1,36 +1,45 @@
-import React from "react";
-import { AreaChart } from "lucide-react";
-import InputField from "./input-field";
-import type { Metadata } from "next";
-import { constructMetadata } from "@/lib/utils";
+import React from "react"
+import { AreaChart } from "lucide-react"
+import InputField from "./input-field"
+import type { Metadata } from "next"
+import { constructMetadata } from "@/lib/utils"
+import { FadeIn } from "@/components/motion"
+import { safeDecodeURIComponent } from "@/lib/safe-decode"
 
 export const metadata: Metadata = constructMetadata({
   title: "Sitemap Link Checker | SeoCheckup",
   description: "Easily review your sitemap by adding yoursite.com/sitemap.xml.",
   canonical: "/sitemap",
   ogImage: "/og-dark.png",
-});
+})
 
-export const revalidate = 0;
+export const revalidate = 0
 
-const Sitemap = ({ searchParams }: { searchParams: { q: string } }) => {
+export default async function Sitemap({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>
+}) {
+  const { q } = await searchParams
+  const query = safeDecodeURIComponent(q)
+
   return (
     <div className="min-h-screen max-h-full flex items-center flex-col pb-10">
-      <section className="flex justify-center flex-col items-center gap-4 mt-3">
-        <div
-          className="w-11 h-11 flex justify-center items-center rounded-lg
-       bg-gradient-to-br from-secondary via-black/20 to-secondary/20 dark:from-primary/30 dark:via-primary/50 dark:to-primary text-black backdrop-blur-md"
-        >
-          <AreaChart />
-        </div>
-        <h2 className="text-center text-2xl font-semibold">
-          Sitemap Link Checker
-        </h2>
-      </section>
+      <FadeIn>
+        <section className="flex justify-center flex-col items-center gap-4 mt-3">
+          <div
+            className="w-11 h-11 flex justify-center items-center rounded-lg
+         bg-gradient-to-br from-secondary via-black/20 to-secondary/20 dark:from-primary/30 dark:via-primary/50 dark:to-primary text-black backdrop-blur-md"
+          >
+            <AreaChart />
+          </div>
+          <h2 className="text-center text-2xl font-semibold">
+            Sitemap Link Checker
+          </h2>
+        </section>
+      </FadeIn>
 
-      <InputField query={decodeURIComponent(searchParams.q)} />
+      <InputField key={query || "default"} query={query} />
     </div>
-  );
-};
-
-export default Sitemap;
+  )
+}

--- a/app/api/audit/route.ts
+++ b/app/api/audit/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from "next/server"
 import { runAudit } from "@/lib/audit/run-audit"
 import { getClientIp } from "@/lib/client-ip"
+import { postDiscordLogs } from "@/lib/discord-webhook"
+import { normalizeOrigin } from "@/lib/fetch-url"
 import getRatelimit from "@/lib/rate-limit"
+import { assertPublicHttpUrl } from "@/lib/safe-url"
 
 export const maxDuration = 60
 
@@ -40,11 +43,17 @@ export async function GET(req: Request) {
   }
 
   try {
+    const origin = normalizeOrigin(decoded)
+    await assertPublicHttpUrl(origin.href)
     const report = await runAudit(decoded)
+    void postDiscordLogs(report.origin, "AUDIT")
     return NextResponse.json(report)
   } catch (err) {
     const message = err instanceof Error ? err.message : "Audit failed"
-    const status = message.includes("http") || message.includes("URL") ? 400 : 500
+    const status =
+      /http|URL|Host|DNS|private|reserved|credentials|ports/i.test(message)
+        ? 400
+        : 500
     return NextResponse.json({ error: message }, { status })
   }
 }

--- a/app/api/audit/route.ts
+++ b/app/api/audit/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server"
+import { runAudit } from "@/lib/audit/run-audit"
+import { getClientIp } from "@/lib/client-ip"
+import getRatelimit from "@/lib/rate-limit"
+
+export const maxDuration = 60
+
+const rateLimit = getRatelimit(15, "24 h")
+
+export async function GET(req: Request) {
+  const ip = getClientIp(req)
+  const { success, limit, reset, remaining } = await rateLimit.limit(
+    `audit:${ip}`
+  )
+
+  if (!success) {
+    return NextResponse.json(
+      { error: "Rate limit exceeded", limit, reset, remaining },
+      {
+        status: 429,
+        headers: {
+          "X-RateLimit-Limit": String(limit),
+          "X-RateLimit-Reset": String(reset),
+          "X-RateLimit-Remaining": String(remaining),
+        },
+      }
+    )
+  }
+
+  const q = new URL(req.url).searchParams.get("q")
+  if (!q) {
+    return NextResponse.json({ error: "Missing q parameter" }, { status: 400 })
+  }
+
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(q)
+  } catch {
+    return NextResponse.json({ error: "Invalid q parameter" }, { status: 400 })
+  }
+
+  try {
+    const report = await runAudit(decoded)
+    return NextResponse.json(report)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Audit failed"
+    const status = message.includes("http") || message.includes("URL") ? 400 : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/domain-rating/route.ts
+++ b/app/api/domain-rating/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server"
+import {
+  AHREFS_DR_ATTRIBUTION,
+  fetchDomainRating,
+} from "@/lib/ahrefs-dr"
+import { getClientIp } from "@/lib/client-ip"
+import { hostnameFromInput } from "@/lib/fetch-url"
+import getRatelimit from "@/lib/rate-limit"
+
+const rateLimit = getRatelimit(30, "24 h")
+
+export async function GET(req: Request) {
+  const ip = getClientIp(req)
+  const { success, limit, reset, remaining } = await rateLimit.limit(`dr:${ip}`)
+
+  if (!success) {
+    return NextResponse.json(
+      { error: "Rate limit exceeded", limit, reset, remaining },
+      {
+        status: 429,
+        headers: {
+          "X-RateLimit-Limit": String(limit),
+          "X-RateLimit-Reset": String(reset),
+          "X-RateLimit-Remaining": String(remaining),
+        },
+      }
+    )
+  }
+
+  const q = new URL(req.url).searchParams.get("q")
+  if (!q) {
+    return NextResponse.json({ error: "Missing q parameter" }, { status: 400 })
+  }
+
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(q)
+  } catch {
+    return NextResponse.json({ error: "Invalid q parameter" }, { status: 400 })
+  }
+
+  let domain: string
+  try {
+    domain = hostnameFromInput(decoded)
+  } catch {
+    return NextResponse.json({ error: "Invalid URL or domain" }, { status: 400 })
+  }
+
+  const result = await fetchDomainRating(domain)
+  if (result.domainRating === null) {
+    return NextResponse.json(
+      {
+        error: result.error || "Domain rating unavailable",
+        domain: result.domain,
+        attribution: AHREFS_DR_ATTRIBUTION,
+      },
+      { status: 502 }
+    )
+  }
+
+  return NextResponse.json({
+    domain: result.domain,
+    domainRating: result.domainRating,
+    attribution: AHREFS_DR_ATTRIBUTION,
+  })
+}

--- a/app/api/domain-rating/route.ts
+++ b/app/api/domain-rating/route.ts
@@ -4,8 +4,10 @@ import {
   fetchDomainRating,
 } from "@/lib/ahrefs-dr"
 import { getClientIp } from "@/lib/client-ip"
+import { postDiscordLogs } from "@/lib/discord-webhook"
 import { hostnameFromInput } from "@/lib/fetch-url"
 import getRatelimit from "@/lib/rate-limit"
+import { assertPublicHttpUrl } from "@/lib/safe-url"
 
 const rateLimit = getRatelimit(30, "24 h")
 
@@ -42,6 +44,7 @@ export async function GET(req: Request) {
   let domain: string
   try {
     domain = hostnameFromInput(decoded)
+    await assertPublicHttpUrl(`https://${domain}/`)
   } catch {
     return NextResponse.json({ error: "Invalid URL or domain" }, { status: 400 })
   }
@@ -57,6 +60,8 @@ export async function GET(req: Request) {
       { status: 502 }
     )
   }
+
+  void postDiscordLogs(result.domain, "DOMAIN_RATING")
 
   return NextResponse.json({
     domain: result.domain,

--- a/app/api/logs/route.ts
+++ b/app/api/logs/route.ts
@@ -1,48 +1,12 @@
 import { NextResponse } from "next/server"
-import { postDiscordLogs, type LogType } from "@/lib/discord-webhook"
-import getRatelimit from "@/lib/rate-limit"
-import { getClientIp } from "@/lib/client-ip"
 
-const ALLOWED: LogType[] = [
-  "SITEMAP",
-  "METADATA",
-  "ROBOTS",
-  "AUDIT",
-  "DOMAIN_RATING",
-]
-const rateLimit = getRatelimit(40, "24 h")
-
-export async function POST(req: Request) {
-  const ip = getClientIp(req)
-  const { success, limit, reset, remaining } = await rateLimit.limit(
-    `logs:${ip}`
+/**
+ * Client-triggered Discord logging is disabled.
+ * Tool routes log server-side after successful work.
+ */
+export async function POST() {
+  return NextResponse.json(
+    { error: "Client logging disabled; use tool APIs" },
+    { status: 410 }
   )
-
-  if (!success) {
-    return NextResponse.json(
-      { error: "Rate limit exceeded", limit, reset, remaining },
-      { status: 429 }
-    )
-  }
-
-  let body: { value?: string; type?: string }
-  try {
-    body = await req.json()
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
-  }
-
-  const value = typeof body.value === "string" ? body.value.trim() : ""
-  const type = body.type
-
-  if (!value || value.length > 2048) {
-    return NextResponse.json({ error: "Invalid value" }, { status: 400 })
-  }
-
-  if (!type || !ALLOWED.includes(type as LogType)) {
-    return NextResponse.json({ error: "Invalid type" }, { status: 400 })
-  }
-
-  await postDiscordLogs(value, type as LogType)
-  return NextResponse.json({ ok: true })
 }

--- a/app/api/logs/route.ts
+++ b/app/api/logs/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server"
+import { postDiscordLogs, type LogType } from "@/lib/discord-webhook"
+import getRatelimit from "@/lib/rate-limit"
+import { getClientIp } from "@/lib/client-ip"
+
+const ALLOWED: LogType[] = ["SITEMAP", "METADATA", "ROBOTS"]
+const rateLimit = getRatelimit(40, "24 h")
+
+export async function POST(req: Request) {
+  const ip = getClientIp(req)
+  const { success, limit, reset, remaining } = await rateLimit.limit(
+    `logs:${ip}`
+  )
+
+  if (!success) {
+    return NextResponse.json(
+      { error: "Rate limit exceeded", limit, reset, remaining },
+      { status: 429 }
+    )
+  }
+
+  let body: { value?: string; type?: string }
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
+  }
+
+  const value = typeof body.value === "string" ? body.value.trim() : ""
+  const type = body.type
+
+  if (!value || value.length > 2048) {
+    return NextResponse.json({ error: "Invalid value" }, { status: 400 })
+  }
+
+  if (!type || !ALLOWED.includes(type as LogType)) {
+    return NextResponse.json({ error: "Invalid type" }, { status: 400 })
+  }
+
+  await postDiscordLogs(value, type as LogType)
+  return NextResponse.json({ ok: true })
+}

--- a/app/api/logs/route.ts
+++ b/app/api/logs/route.ts
@@ -3,7 +3,13 @@ import { postDiscordLogs, type LogType } from "@/lib/discord-webhook"
 import getRatelimit from "@/lib/rate-limit"
 import { getClientIp } from "@/lib/client-ip"
 
-const ALLOWED: LogType[] = ["SITEMAP", "METADATA", "ROBOTS"]
+const ALLOWED: LogType[] = [
+  "SITEMAP",
+  "METADATA",
+  "ROBOTS",
+  "AUDIT",
+  "DOMAIN_RATING",
+]
 const rateLimit = getRatelimit(40, "24 h")
 
 export async function POST(req: Request) {

--- a/app/api/sitemap/route.ts
+++ b/app/api/sitemap/route.ts
@@ -1,13 +1,17 @@
 import { NextResponse } from "next/server"
-import getRatelimit from "@/lib/rate-limit"
+import { postDiscordLogs } from "@/lib/discord-webhook"
 import { getClientIp } from "@/lib/client-ip"
+import getRatelimit from "@/lib/rate-limit"
 import { expandSitemap } from "@/lib/sitemap-expand"
+import { assertPublicHttpUrl } from "@/lib/safe-url"
 
 const rateLimit = getRatelimit(20, "24 h")
 
 export async function GET(req: Request) {
   const ip = getClientIp(req)
-  const { success, limit, reset, remaining } = await rateLimit.limit(ip)
+  const { success, limit, reset, remaining } = await rateLimit.limit(
+    `sitemap:${ip}`
+  )
 
   if (!success) {
     return NextResponse.json(
@@ -35,22 +39,18 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: "Invalid q parameter" }, { status: 400 })
   }
 
-  let parsed: URL
   try {
-    parsed = new URL(url)
-  } catch {
-    return NextResponse.json({ error: "Invalid URL" }, { status: 400 })
-  }
-
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    await assertPublicHttpUrl(url)
+  } catch (err) {
     return NextResponse.json(
-      { error: "Only http and https URLs are allowed" },
+      { error: err instanceof Error ? err.message : "Invalid URL" },
       { status: 400 }
     )
   }
 
   try {
-    const result = await expandSitemap(parsed.href)
+    const result = await expandSitemap(url)
+    void postDiscordLogs(url, "SITEMAP")
     return NextResponse.json(result)
   } catch (error) {
     console.error("Error expanding sitemap:", error)

--- a/app/api/sitemap/route.ts
+++ b/app/api/sitemap/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server"
+import getRatelimit from "@/lib/rate-limit"
+import { getClientIp } from "@/lib/client-ip"
+import { expandSitemap } from "@/lib/sitemap-expand"
+
+const rateLimit = getRatelimit(20, "24 h")
+
+export async function GET(req: Request) {
+  const ip = getClientIp(req)
+  const { success, limit, reset, remaining } = await rateLimit.limit(ip)
+
+  if (!success) {
+    return NextResponse.json(
+      { error: "Rate limit exceeded", limit, reset, remaining },
+      {
+        status: 429,
+        headers: {
+          "X-RateLimit-Limit": String(limit),
+          "X-RateLimit-Reset": String(reset),
+          "X-RateLimit-Remaining": String(remaining),
+        },
+      }
+    )
+  }
+
+  const q = new URL(req.url).searchParams.get("q")
+  if (!q) {
+    return NextResponse.json({ error: "Missing q parameter" }, { status: 400 })
+  }
+
+  let url: string
+  try {
+    url = decodeURIComponent(q)
+  } catch {
+    return NextResponse.json({ error: "Invalid q parameter" }, { status: 400 })
+  }
+
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return NextResponse.json({ error: "Invalid URL" }, { status: 400 })
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return NextResponse.json(
+      { error: "Only http and https URLs are allowed" },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const result = await expandSitemap(parsed.href)
+    return NextResponse.json(result)
+  } catch (error) {
+    console.error("Error expanding sitemap:", error)
+    const message =
+      error instanceof Error ? error.message : "Error expanding sitemap"
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/v1/route.ts
+++ b/app/api/v1/route.ts
@@ -1,48 +1,71 @@
-import { NextResponse } from "next/server";
-import getRatelimit from "@/lib/rate-limit";
+import { NextResponse } from "next/server"
+import getRatelimit from "@/lib/rate-limit"
+import { getClientIp } from "@/lib/client-ip"
 
-const rateLimit = getRatelimit(20, "24 h");
+const rateLimit = getRatelimit(20, "24 h")
 
 export async function GET(req: Request) {
-  const value = req.url.split("q=")[1];
-  const ip = req.headers.get("x-forwarded-for") ?? "127.0.0.1";
-  const url = decodeURIComponent(value);
-
-  const { success, limit, reset, remaining } = await rateLimit.limit(ip);
+  const ip = getClientIp(req)
+  const { success, limit, reset, remaining } = await rateLimit.limit(ip)
 
   if (!success) {
-    return NextResponse.json({
-      error: "Rate limit exceeded",
-      data: {
-        limit,
-        reset,
-        remaining,
-      },
-      status: 429,
-      headers: {
-        "X-RateLimit-Limit": limit.toString(),
-        "X-RateLimit-Reset": reset.toString(),
-        "X-RateLimit-Remaining": remaining.toString(),
-      },
-    });
+    return NextResponse.json(
+      { error: "Rate limit exceeded", limit, reset, remaining },
+      {
+        status: 429,
+        headers: {
+          "X-RateLimit-Limit": String(limit),
+          "X-RateLimit-Reset": String(reset),
+          "X-RateLimit-Remaining": String(remaining),
+        },
+      }
+    )
+  }
+
+  const q = new URL(req.url).searchParams.get("q")
+  if (!q) {
+    return NextResponse.json({ error: "Missing q parameter" }, { status: 400 })
+  }
+
+  let url: string
+  try {
+    url = decodeURIComponent(q)
+  } catch {
+    return NextResponse.json({ error: "Invalid q parameter" }, { status: 400 })
+  }
+
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return NextResponse.json({ error: "Invalid URL" }, { status: 400 })
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return NextResponse.json(
+      { error: "Only http and https URLs are allowed" },
+      { status: 400 }
+    )
   }
 
   try {
-    const data = await fetch(url);
+    const data = await fetch(url, {
+      redirect: "follow",
+      signal: AbortSignal.timeout(15_000),
+    })
 
     if (!data.ok) {
-      console.error("Failed to fetch data:", data.statusText);
-      return NextResponse.json({
-        error: "Failed to fetch data",
-        status: data.status,
-      });
+      return NextResponse.json(
+        { error: "Failed to fetch data", status: data.status },
+        { status: data.status }
+      )
     }
 
-    const res = await data.text();
-
-    return NextResponse.json(res);
+    const res = await data.text()
+    const capped = res.length > 2_000_000 ? res.slice(0, 2_000_000) : res
+    return NextResponse.json(capped)
   } catch (error) {
-    console.error("Error fetching data:", error);
-    return NextResponse.json({ error: "Error fetching data", status: 500 });
+    console.error("Error fetching data:", error)
+    return NextResponse.json({ error: "Error fetching data" }, { status: 500 })
   }
 }

--- a/app/api/v1/route.ts
+++ b/app/api/v1/route.ts
@@ -1,12 +1,15 @@
 import { NextResponse } from "next/server"
-import getRatelimit from "@/lib/rate-limit"
+import { postDiscordLogs, type LogType } from "@/lib/discord-webhook"
 import { getClientIp } from "@/lib/client-ip"
+import getRatelimit from "@/lib/rate-limit"
+import { safeFetch } from "@/lib/safe-fetch"
+import { assertPublicHttpUrl } from "@/lib/safe-url"
 
 const rateLimit = getRatelimit(20, "24 h")
 
 export async function GET(req: Request) {
   const ip = getClientIp(req)
-  const { success, limit, reset, remaining } = await rateLimit.limit(ip)
+  const { success, limit, reset, remaining } = await rateLimit.limit(`v1:${ip}`)
 
   if (!success) {
     return NextResponse.json(
@@ -22,7 +25,8 @@ export async function GET(req: Request) {
     )
   }
 
-  const q = new URL(req.url).searchParams.get("q")
+  const search = new URL(req.url).searchParams
+  const q = search.get("q")
   if (!q) {
     return NextResponse.json({ error: "Missing q parameter" }, { status: 400 })
   }
@@ -34,36 +38,34 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: "Invalid q parameter" }, { status: 400 })
   }
 
-  let parsed: URL
   try {
-    parsed = new URL(url)
-  } catch {
-    return NextResponse.json({ error: "Invalid URL" }, { status: 400 })
-  }
-
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    await assertPublicHttpUrl(url)
+  } catch (err) {
     return NextResponse.json(
-      { error: "Only http and https URLs are allowed" },
+      { error: err instanceof Error ? err.message : "Invalid URL" },
       { status: 400 }
     )
   }
 
+  const tool = search.get("tool")
+  const logType: LogType | null =
+    tool === "METADATA" || tool === "ROBOTS" ? tool : null
+
   try {
-    const data = await fetch(url, {
-      redirect: "follow",
-      signal: AbortSignal.timeout(15_000),
-    })
+    const data = await safeFetch(url)
 
     if (!data.ok) {
       return NextResponse.json(
-        { error: "Failed to fetch data", status: data.status },
-        { status: data.status }
+        { error: data.error || "Failed to fetch data", status: data.status },
+        { status: data.status || 502 }
       )
     }
 
-    const res = await data.text()
-    const capped = res.length > 2_000_000 ? res.slice(0, 2_000_000) : res
-    return NextResponse.json(capped)
+    if (logType) {
+      void postDiscordLogs(url, logType)
+    }
+
+    return NextResponse.json(data.body.toString("utf8"))
   } catch (error) {
     console.error("Error fetching data:", error)
     return NextResponse.json({ error: "Error fetching data" }, { status: 500 })

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,125 @@
+import { Button } from "@/components/ui/button"
+import {
+  type BlogSlug,
+  blogMetadata,
+  blogSlugs,
+  getBlogPosts,
+} from "@/lib/blog-metadata"
+import { constructMetadata } from "@/lib/utils"
+import type { Metadata } from "next"
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import type { ComponentType } from "react"
+
+import FreeWebsiteSeoAudit from "@/content/blog/free-website-seo-audit.mdx"
+import HowToCheckMetaTags from "@/content/blog/how-to-check-meta-tags.mdx"
+import HowToCheckRobotsTxt from "@/content/blog/how-to-check-robots-txt.mdx"
+import HowToCheckXmlSitemap from "@/content/blog/how-to-check-xml-sitemap.mdx"
+import WhatIsDomainRating from "@/content/blog/what-is-domain-rating.mdx"
+
+const blogComponents: Record<BlogSlug, ComponentType> = {
+  "free-website-seo-audit": FreeWebsiteSeoAudit,
+  "what-is-domain-rating": WhatIsDomainRating,
+  "how-to-check-xml-sitemap": HowToCheckXmlSitemap,
+  "how-to-check-meta-tags": HowToCheckMetaTags,
+  "how-to-check-robots-txt": HowToCheckRobotsTxt,
+}
+
+export function generateStaticParams() {
+  return blogSlugs.map((slug) => ({ slug }))
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
+  const { slug } = await params
+  if (!(slug in blogMetadata)) {
+    return constructMetadata({ canonical: "/blog" })
+  }
+  const meta = blogMetadata[slug as BlogSlug]
+  return constructMetadata({
+    title: `${meta.title} | SeoCheckup`,
+    description: meta.description,
+    canonical: `/blog/${slug}`,
+    ogImage: meta.coverImage,
+  })
+}
+
+export default async function BlogPostPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  if (!(slug in blogMetadata) || !(slug in blogComponents)) {
+    notFound()
+  }
+
+  const meta = blogMetadata[slug as BlogSlug]
+  const Content = blogComponents[slug as BlogSlug]
+  const related = getBlogPosts()
+    .filter((p) => p.slug !== slug)
+    .slice(0, 3)
+
+  return (
+    <article className="pb-16">
+      <div
+        className="w-full h-56 sm:h-72 md:h-80 bg-cover bg-center relative"
+        style={{ backgroundImage: `url(${meta.coverImage})` }}
+      >
+        <div className="absolute inset-0 bg-gradient-to-b from-transparent to-background" />
+      </div>
+
+      <div className="max-w-6xl mx-auto px-4 -mt-16 relative">
+        <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_240px] gap-10">
+          <div>
+            <p className="text-xs font-mono text-muted-foreground">
+              {meta.category} · {meta.date} · {meta.readTime}
+            </p>
+            <div className="mt-4 prose prose-neutral dark:prose-invert max-w-3xl">
+              <Content />
+            </div>
+          </div>
+
+          <aside className="xl:sticky xl:top-28 h-fit space-y-4">
+            <div className="border rounded-xl p-4 bg-muted/30">
+              <p className="text-sm font-medium">Try the tool</p>
+              <p className="text-xs text-muted-foreground mt-1">
+                Run this related SeoCheckup feature free.
+              </p>
+              <Button asChild className="mt-3 w-full">
+                <Link href={meta.relatedTool.href}>{meta.relatedTool.label}</Link>
+              </Button>
+            </div>
+            <Link
+              href="/blog"
+              className="text-sm underline underline-offset-2 text-muted-foreground"
+            >
+              ← All posts
+            </Link>
+          </aside>
+        </div>
+
+        <section className="mt-16 border-t pt-10">
+          <h2 className="text-lg font-semibold">Related posts</h2>
+          <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
+            {related.map((post) => (
+              <Link
+                key={post.slug}
+                href={`/blog/${post.slug}`}
+                className="border rounded-lg p-4 hover:bg-muted/40 transition-colors"
+              >
+                <p className="text-xs font-mono text-muted-foreground">
+                  {post.category}
+                </p>
+                <p className="mt-1 font-medium text-sm">{post.title}</p>
+              </Link>
+            ))}
+          </div>
+        </section>
+      </div>
+    </article>
+  )
+}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import JsonLd from "@/components/json-ld"
 import { Button } from "@/components/ui/button"
 import {
   type BlogSlug,
@@ -5,6 +6,7 @@ import {
   blogSlugs,
   getBlogPosts,
 } from "@/lib/blog-metadata"
+import { SITE_URL, absoluteUrl } from "@/lib/site"
 import { constructMetadata } from "@/lib/utils"
 import type { Metadata } from "next"
 import Link from "next/link"
@@ -62,7 +64,7 @@ export default async function BlogPostPage({
   const related = getBlogPosts()
     .filter((p) => p.slug !== slug)
     .slice(0, 3)
-  const pageUrl = `https://seocheckup.vercel.app/blog/${slug}`
+  const pageUrl = absoluteUrl(`/blog/${slug}`)
   const articleJsonLd = {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
@@ -70,9 +72,12 @@ export default async function BlogPostPage({
     description: meta.description,
     datePublished: meta.date,
     dateModified: meta.date,
-    image: `https://seocheckup.vercel.app${meta.coverImage}`,
+    image: absoluteUrl(meta.coverImage),
     url: pageUrl,
-    mainEntityOfPage: pageUrl,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": pageUrl,
+    },
     author: {
       "@type": "Person",
       name: "Shriprasanna",
@@ -81,16 +86,13 @@ export default async function BlogPostPage({
     publisher: {
       "@type": "Organization",
       name: "SeoCheckup",
-      url: "https://seocheckup.vercel.app",
+      url: SITE_URL,
     },
   }
 
   return (
     <article className="pb-16">
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
-      />
+      <JsonLd data={articleJsonLd} />
       <div
         className="w-full h-56 sm:h-72 md:h-80 bg-cover bg-center relative"
         style={{ backgroundImage: `url(${meta.coverImage})` }}
@@ -118,6 +120,12 @@ export default async function BlogPostPage({
               <Button asChild className="mt-3 w-full">
                 <Link href={meta.relatedTool.href}>{meta.relatedTool.label}</Link>
               </Button>
+              <Link
+                href={meta.relatedLanding.href}
+                className="mt-3 block text-center text-xs underline underline-offset-2 text-muted-foreground hover:text-foreground"
+              >
+                {meta.relatedLanding.label}
+              </Link>
             </div>
             <Link
               href="/blog"

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -62,9 +62,35 @@ export default async function BlogPostPage({
   const related = getBlogPosts()
     .filter((p) => p.slug !== slug)
     .slice(0, 3)
+  const pageUrl = `https://seocheckup.vercel.app/blog/${slug}`
+  const articleJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: meta.title,
+    description: meta.description,
+    datePublished: meta.date,
+    dateModified: meta.date,
+    image: `https://seocheckup.vercel.app${meta.coverImage}`,
+    url: pageUrl,
+    mainEntityOfPage: pageUrl,
+    author: {
+      "@type": "Person",
+      name: "Shriprasanna",
+      url: "https://github.com/shrix1",
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "SeoCheckup",
+      url: "https://seocheckup.vercel.app",
+    },
+  }
 
   return (
     <article className="pb-16">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
+      />
       <div
         className="w-full h-56 sm:h-72 md:h-80 bg-cover bg-center relative"
         style={{ backgroundImage: `url(${meta.coverImage})` }}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,14 @@
+import BlogExplorer from "@/components/blog-explorer"
+import { constructMetadata } from "@/lib/utils"
+import { Metadata } from "next/types"
+
+export const metadata: Metadata = constructMetadata({
+  title: "Blog | SeoCheckup",
+  description:
+    "Guides on XML sitemaps, meta tags, robots.txt, Domain Rating, and free website SEO audits.",
+  canonical: "/blog",
+})
+
+export default function BlogPage() {
+  return <BlogExplorer />
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,14 +1,35 @@
 import BlogExplorer from "@/components/blog-explorer"
+import JsonLd from "@/components/json-ld"
+import { SITE_URL } from "@/lib/site"
 import { constructMetadata } from "@/lib/utils"
 import { Metadata } from "next/types"
 
 export const metadata: Metadata = constructMetadata({
-  title: "Blog | SeoCheckup",
+  title: "SEO Blog — Audits, Sitemaps & Meta Guides | SeoCheckup",
   description:
-    "Guides on XML sitemaps, meta tags, robots.txt, Domain Rating, and free website SEO audits.",
+    "Practical SEO guides from SeoCheckup: how to run a free site audit, check Domain Rating, validate XML sitemaps, preview meta tags, and read robots.txt without breaking crawl access.",
   canonical: "/blog",
 })
 
+const blogJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  name: "SeoCheckup Blog",
+  description:
+    "Guides on XML sitemaps, meta tags, robots.txt, Domain Rating, and free website SEO audits.",
+  url: `${SITE_URL}/blog`,
+  isPartOf: {
+    "@type": "WebSite",
+    name: "SeoCheckup",
+    url: SITE_URL,
+  },
+}
+
 export default function BlogPage() {
-  return <BlogExplorer />
+  return (
+    <>
+      <JsonLd data={blogJsonLd} />
+      <BlogExplorer />
+    </>
+  )
 }

--- a/app/domain-rating-checker/page.tsx
+++ b/app/domain-rating-checker/page.tsx
@@ -1,0 +1,50 @@
+import SeoToolLanding from "@/components/seo-tool-landing"
+import { constructMetadata } from "@/lib/utils"
+import { Metadata } from "next/types"
+
+export const metadata: Metadata = constructMetadata({
+  title: "Free Domain Rating Checker | SeoCheckup",
+  description:
+    "Check Domain Rating (DR) for any website free using Ahrefs’ public Domain Rating data. Instant authority score with attribution.",
+  canonical: "/domain-rating-checker",
+})
+
+export default function DomainRatingCheckerPage() {
+  return (
+    <SeoToolLanding
+      h1="Free Domain Rating Checker"
+      pitch="Look up Ahrefs Domain Rating for any domain in seconds. Free, no API key, with required Ahrefs attribution."
+      ctaHref="/domain-rating?q=https://shrix1.com"
+      ctaLabel="Check Domain Rating"
+      canonicalPath="/domain-rating-checker"
+      appName="Domain Rating Checker"
+      benefits={[
+        "Instant DR score from Ahrefs’ free public endpoint",
+        "Works with a bare domain or full URL",
+        "Jump into a full SeoCheckup site audit next",
+      ]}
+      faqs={[
+        {
+          question: "What is Domain Rating?",
+          answer:
+            "Domain Rating (DR) is Ahrefs’ score for the relative strength of a site’s backlink profile on a 100-point logarithmic scale.",
+        },
+        {
+          question: "Is this official Ahrefs data?",
+          answer:
+            "Yes. Values come from Ahrefs’ free public Domain Rating API. We display the required “Domain Rating by Ahrefs” attribution.",
+        },
+        {
+          question: "Do I need an Ahrefs subscription?",
+          answer:
+            "No. This checker uses the free public endpoint and does not require an API key or paid plan.",
+        },
+      ]}
+      related={[
+        { href: "/site-audit", label: "Website SEO Audit" },
+        { href: "/sitemap-checker", label: "XML Sitemap Checker" },
+        { href: "/robots-txt-checker", label: "Robots.txt Checker" },
+      ]}
+    />
+  )
+}

--- a/app/domain-rating-checker/page.tsx
+++ b/app/domain-rating-checker/page.tsx
@@ -17,8 +17,9 @@ export default function DomainRatingCheckerPage() {
     <SeoToolLanding
       h1="Free Domain Rating Checker"
       pitch="Look up Ahrefs Domain Rating for any domain in seconds. Free, no API key, with required Ahrefs attribution."
-      ctaHref="/domain-rating?q=https://shrix1.com"
-      ctaLabel="Check Domain Rating"
+      toolPath="/domain-rating"
+      defaultDemoUrl="https://shrix1.com"
+      inputPlaceholder="https://example.com"
       canonicalPath={feature.landingPath}
       appName={feature.appName}
       blogHref={blogPath(feature.blogSlug)}

--- a/app/domain-rating-checker/page.tsx
+++ b/app/domain-rating-checker/page.tsx
@@ -1,12 +1,15 @@
 import SeoToolLanding from "@/components/seo-tool-landing"
+import { blogPath, features } from "@/lib/site"
 import { constructMetadata } from "@/lib/utils"
 import { Metadata } from "next/types"
+
+const feature = features.domainRating
 
 export const metadata: Metadata = constructMetadata({
   title: "Free Domain Rating Checker | SeoCheckup",
   description:
-    "Check Domain Rating (DR) for any website free using Ahrefs’ public Domain Rating data. Instant authority score with attribution.",
-  canonical: "/domain-rating-checker",
+    "Check Domain Rating (DR) for any website free using Ahrefs’ public Domain Rating data. See an instant authority score with required Domain Rating by Ahrefs attribution — no API key.",
+  canonical: feature.landingPath,
 })
 
 export default function DomainRatingCheckerPage() {
@@ -16,8 +19,10 @@ export default function DomainRatingCheckerPage() {
       pitch="Look up Ahrefs Domain Rating for any domain in seconds. Free, no API key, with required Ahrefs attribution."
       ctaHref="/domain-rating?q=https://shrix1.com"
       ctaLabel="Check Domain Rating"
-      canonicalPath="/domain-rating-checker"
-      appName="Domain Rating Checker"
+      canonicalPath={feature.landingPath}
+      appName={feature.appName}
+      blogHref={blogPath(feature.blogSlug)}
+      blogLabel={feature.blogLabel}
       benefits={[
         "Instant DR score from Ahrefs’ free public endpoint",
         "Works with a bare domain or full URL",

--- a/app/globals.css
+++ b/app/globals.css
@@ -28,6 +28,9 @@
     --input: 220 13% 91%;
     --ring: 224 71.4% 4.1%;
     --radius: 0.5rem;
+    --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+    --duration-fast: 150ms;
+    --duration-normal: 250ms;
   }
 
   .dark {
@@ -50,6 +53,19 @@
     --border: 215 27.9% 16.9%;
     --input: 215 27.9% 16.9%;
     --ring: 216 12.2% 83.9%;
+    --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+    --duration-fast: 150ms;
+    --duration-normal: 250ms;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }
 

--- a/app/meta-tags-checker/page.tsx
+++ b/app/meta-tags-checker/page.tsx
@@ -1,12 +1,15 @@
 import SeoToolLanding from "@/components/seo-tool-landing"
+import { blogPath, features } from "@/lib/site"
 import { constructMetadata } from "@/lib/utils"
 import { Metadata } from "next/types"
+
+const feature = features.metadata
 
 export const metadata: Metadata = constructMetadata({
   title: "Free Meta Tags Checker | SeoCheckup",
   description:
-    "Check website meta tags and preview title, description, and Open Graph social cards for Google, X, and more.",
-  canonical: "/meta-tags-checker",
+    "Check website meta tags free: preview title and description as search engines may show them, plus Open Graph social cards, so snippets look right before you publish.",
+  canonical: feature.landingPath,
 })
 
 export default function MetaTagsCheckerPage() {
@@ -15,8 +18,10 @@ export default function MetaTagsCheckerPage() {
       h1="Free Meta Tags Checker"
       pitch="Preview title, description, and social cards so search and share snippets look right before you publish."
       ctaHref="/metadata?q=https://shrix1.com"
-      canonicalPath="/meta-tags-checker"
-      appName="Meta Tags Checker"
+      canonicalPath={feature.landingPath}
+      appName={feature.appName}
+      blogHref={blogPath(feature.blogSlug)}
+      blogLabel={feature.blogLabel}
       benefits={[
         "See title and meta description as search engines may show them",
         "Preview Open Graph and social share cards",
@@ -40,6 +45,7 @@ export default function MetaTagsCheckerPage() {
         },
       ]}
       related={[
+        { href: "/site-audit", label: "Website SEO Audit" },
         { href: "/sitemap-checker", label: "XML Sitemap Checker" },
         { href: "/robots-txt-checker", label: "Robots.txt Checker" },
       ]}

--- a/app/meta-tags-checker/page.tsx
+++ b/app/meta-tags-checker/page.tsx
@@ -1,0 +1,48 @@
+import SeoToolLanding from "@/components/seo-tool-landing"
+import { constructMetadata } from "@/lib/utils"
+import { Metadata } from "next/types"
+
+export const metadata: Metadata = constructMetadata({
+  title: "Free Meta Tags Checker | SeoCheckup",
+  description:
+    "Check website meta tags and preview title, description, and Open Graph social cards for Google, X, and more.",
+  canonical: "/meta-tags-checker",
+})
+
+export default function MetaTagsCheckerPage() {
+  return (
+    <SeoToolLanding
+      h1="Free Meta Tags Checker"
+      pitch="Preview title, description, and social cards so search and share snippets look right before you publish."
+      ctaHref="/metadata?q=https://shrix1.com"
+      canonicalPath="/meta-tags-checker"
+      appName="Meta Tags Checker"
+      benefits={[
+        "See title and meta description as search engines may show them",
+        "Preview Open Graph and social share cards",
+        "Spot missing or weak tags in seconds",
+      ]}
+      faqs={[
+        {
+          question: "What is the difference between title and description?",
+          answer:
+            "The title tag is the clickable headline in search results. The meta description is the supporting snippet underneath. Both should be unique and match the page content.",
+        },
+        {
+          question: "What are Open Graph tags?",
+          answer:
+            "Open Graph meta tags control how a page looks when shared on social platforms — typically image, title, and description for the share card.",
+        },
+        {
+          question: "Why do meta tag previews matter?",
+          answer:
+            "Clear titles and descriptions improve click-through from search and social. Checking them before launch avoids broken or empty previews.",
+        },
+      ]}
+      related={[
+        { href: "/sitemap-checker", label: "XML Sitemap Checker" },
+        { href: "/robots-txt-checker", label: "Robots.txt Checker" },
+      ]}
+    />
+  )
+}

--- a/app/meta-tags-checker/page.tsx
+++ b/app/meta-tags-checker/page.tsx
@@ -17,7 +17,9 @@ export default function MetaTagsCheckerPage() {
     <SeoToolLanding
       h1="Free Meta Tags Checker"
       pitch="Preview title, description, and social cards so search and share snippets look right before you publish."
-      ctaHref="/metadata?q=https://shrix1.com"
+      toolPath="/metadata"
+      defaultDemoUrl="https://shrix1.com"
+      inputPlaceholder="https://example.com"
       canonicalPath={feature.landingPath}
       appName={feature.appName}
       blogHref={blogPath(feature.blogSlug)}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,4 @@
-import ToolCard from "@/components/tool-card"
-import { FadeIn, StaggerChildren, StaggerItem } from "@/components/motion"
+import HomeHero from "@/components/home-hero"
 import { constructMetadata } from "@/lib/utils"
 import { Metadata } from "next/types"
 
@@ -8,59 +7,5 @@ export const metadata: Metadata = constructMetadata({
 })
 
 export default function Home() {
-  const tools = [
-    {
-      id: 1,
-      title: "Sitemap Link Checker",
-      content: "Easily review your sitemap by adding yoursite.com/sitemap.xml.",
-      link: "/sitemap-checker",
-    },
-    {
-      id: 2,
-      title: "Metadata viewer",
-      content: "Easily review your metadata by adding your site link.",
-      link: "/meta-tags-checker",
-    },
-    {
-      id: 3,
-      title: "Robots.txt Viewer",
-      content: "Inspect robots.txt directives, sitemaps, and crawl rules.",
-      link: "/robots-txt-checker",
-    },
-  ]
-
-  return (
-    <section className="relative flex justify-center flex-col items-center min-h-[83vh]">
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 -z-10 bg-background
-          bg-[linear-gradient(to_right,hsl(var(--border))_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--border))_1px,transparent_1px)]
-          bg-[size:6rem_4rem]
-          [mask-image:radial-gradient(ellipse_70%_60%_at_50%_30%,black,transparent)]"
-      />
-
-      <main className="flex justify-center flex-col items-center w-full px-4 py-16 md:py-24">
-        <FadeIn className="flex flex-col items-center text-center max-w-2xl">
-          <h1 className="text-5xl sm:text-6xl md:text-7xl font-bold tracking-tight font-mono">
-            SeoCheckup
-          </h1>
-          <p className="mt-4 text-base sm:text-lg text-muted-foreground max-w-md">
-            Free SEO tools to inspect sitemaps, metadata, and robots.txt.
-          </p>
-        </FadeIn>
-
-        <StaggerChildren className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-12 w-full max-w-5xl">
-          {tools.map((tool) => (
-            <StaggerItem key={tool.id}>
-              <ToolCard
-                title={tool.title}
-                content={tool.content}
-                link={tool.link}
-              />
-            </StaggerItem>
-          ))}
-        </StaggerChildren>
-      </main>
-    </section>
-  )
+  return <HomeHero />
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import ToolCard from "@/components/tool-card"
+import { FadeIn, StaggerChildren, StaggerItem } from "@/components/motion"
 import { constructMetadata } from "@/lib/utils"
 import { Metadata } from "next/types"
 
@@ -20,28 +21,45 @@ export default function Home() {
       content: "Easily review your metadata by adding your site link.",
       link: "/metadata?q=https://supwriter.com",
     },
+    {
+      id: 3,
+      title: "Robots.txt Viewer",
+      content: "Inspect robots.txt directives, sitemaps, and crawl rules.",
+      link: "/robots?q=https://freetoolsfr.com/robots.txt",
+    },
   ]
 
   return (
-    <section className="flex justify-center flex-col items-center">
-      <div className="absolute inset-0 -z-10 h-full w-full bg-white dark:bg-background dark:bg-[linear-gradient(to_right,#202121,transparent_1px),linear-gradient(to_bottom,#202121,transparent_1px)]  bg-[linear-gradient(to_right,#f0f0f0_1px,transparent_1px),linear-gradient(to_bottom,#f0f0f0_1px,transparent_1px)] bg-[size:6rem_4rem]"></div>
+    <section className="relative flex justify-center flex-col items-center min-h-[83vh]">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10 bg-background
+          bg-[linear-gradient(to_right,hsl(var(--border))_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--border))_1px,transparent_1px)]
+          bg-[size:6rem_4rem]
+          [mask-image:radial-gradient(ellipse_70%_60%_at_50%_30%,black,transparent)]"
+      />
 
-      <main className="flex justify-center flex-col items-center w-full h-[90vh] md:h-[83vh]">
-        <h1 className="text-5xl sm:text-6xl md:text-7xl -mt-10 font-bold text-center bg-clip-text text-transparent bg-gradient-to-br from-primary/40 via-primary to-primary/40">
-          Check Your Sitemap <br />
-          and Metadata here
-        </h1>
+      <main className="flex justify-center flex-col items-center w-full px-4 py-16 md:py-24">
+        <FadeIn className="flex flex-col items-center text-center max-w-2xl">
+          <h1 className="text-5xl sm:text-6xl md:text-7xl font-bold tracking-tight font-mono">
+            SeoCheckup
+          </h1>
+          <p className="mt-4 text-base sm:text-lg text-muted-foreground max-w-md">
+            Free SEO tools to inspect sitemaps, metadata, and robots.txt.
+          </p>
+        </FadeIn>
 
-        <section className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-10 px-4 md:px-0">
+        <StaggerChildren className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-12 w-full max-w-5xl">
           {tools.map((tool) => (
-            <ToolCard
-              key={tool.id}
-              title={tool.title}
-              content={tool.content}
-              link={tool.link}
-            />
+            <StaggerItem key={tool.id}>
+              <ToolCard
+                title={tool.title}
+                content={tool.content}
+                link={tool.link}
+              />
+            </StaggerItem>
           ))}
-        </section>
+        </StaggerChildren>
       </main>
     </section>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,19 +13,19 @@ export default function Home() {
       id: 1,
       title: "Sitemap Link Checker",
       content: "Easily review your sitemap by adding yoursite.com/sitemap.xml.",
-      link: "/sitemap?q=https://shrix1.com/sitemap.xml",
+      link: "/sitemap-checker",
     },
     {
       id: 2,
       title: "Metadata viewer",
       content: "Easily review your metadata by adding your site link.",
-      link: "/metadata?q=https://shrix1.com",
+      link: "/meta-tags-checker",
     },
     {
       id: 3,
       title: "Robots.txt Viewer",
       content: "Inspect robots.txt directives, sitemaps, and crawl rules.",
-      link: "/robots?q=https://shrix1.com/robots.txt",
+      link: "/robots-txt-checker",
     },
   ]
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import { Metadata } from "next/types"
 export const metadata: Metadata = constructMetadata({
   title: "SeoCheckup — Free Site Audit & SEO Tools",
   description:
-    "Free website SEO tools: run a technical site audit, check Ahrefs Domain Rating, expand XML sitemaps, preview meta tags and Open Graph cards, and inspect robots.txt — no account required.",
+    "Free site audit for any website — check sitemap, meta tags, robots.txt, and Domain Rating in one go.",
   canonical: "/",
 })
 
@@ -17,7 +17,7 @@ const websiteJsonLd = {
   name: "SeoCheckup",
   url: SITE_URL,
   description:
-    "Free website SEO audit, Domain Rating checker, XML sitemap expander, meta tags preview, and robots.txt viewer.",
+    "Free site audit for any website — check sitemap, meta tags, robots.txt, and Domain Rating in one go.",
   publisher: {
     "@type": "Organization",
     name: "SeoCheckup",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,19 +13,19 @@ export default function Home() {
       id: 1,
       title: "Sitemap Link Checker",
       content: "Easily review your sitemap by adding yoursite.com/sitemap.xml.",
-      link: "/sitemap?q=https://supwriter.com/sitemap.xml",
+      link: "/sitemap?q=https://shrix1.com/sitemap.xml",
     },
     {
       id: 2,
       title: "Metadata viewer",
       content: "Easily review your metadata by adding your site link.",
-      link: "/metadata?q=https://supwriter.com",
+      link: "/metadata?q=https://shrix1.com",
     },
     {
       id: 3,
       title: "Robots.txt Viewer",
       content: "Inspect robots.txt directives, sitemaps, and crawl rules.",
-      link: "/robots?q=https://supwriter.com/robots.txt",
+      link: "/robots?q=https://shrix1.com/robots.txt",
     },
   ]
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,47 @@
 import HomeHero from "@/components/home-hero"
+import JsonLd from "@/components/json-ld"
+import { SITE_URL } from "@/lib/site"
 import { constructMetadata } from "@/lib/utils"
 import { Metadata } from "next/types"
 
 export const metadata: Metadata = constructMetadata({
+  title: "SeoCheckup — Free Site Audit & SEO Tools",
+  description:
+    "Free website SEO tools: run a technical site audit, check Ahrefs Domain Rating, expand XML sitemaps, preview meta tags and Open Graph cards, and inspect robots.txt — no account required.",
   canonical: "/",
 })
 
+const websiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "SeoCheckup",
+  url: SITE_URL,
+  description:
+    "Free website SEO audit, Domain Rating checker, XML sitemap expander, meta tags preview, and robots.txt viewer.",
+  publisher: {
+    "@type": "Organization",
+    name: "SeoCheckup",
+    url: SITE_URL,
+  },
+}
+
+const organizationJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "SeoCheckup",
+  url: SITE_URL,
+  sameAs: [
+    "https://github.com/shrix1/seo-checkup",
+    "https://x.com/shribuilds",
+  ],
+}
+
 export default function Home() {
-  return <HomeHero />
+  return (
+    <>
+      <JsonLd data={websiteJsonLd} />
+      <JsonLd data={organizationJsonLd} />
+      <HomeHero />
+    </>
+  )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,7 @@ export default function Home() {
       id: 1,
       title: "Sitemap Link Checker",
       content: "Easily review your sitemap by adding yoursite.com/sitemap.xml.",
-      link: "/sitemap?q=https://freetoolsfr.com/sitemap.xml",
+      link: "/sitemap?q=https://supwriter.com/sitemap.xml",
     },
     {
       id: 2,
@@ -25,7 +25,7 @@ export default function Home() {
       id: 3,
       title: "Robots.txt Viewer",
       content: "Inspect robots.txt directives, sitemaps, and crawl rules.",
-      link: "/robots?q=https://freetoolsfr.com/robots.txt",
+      link: "/robots?q=https://supwriter.com/robots.txt",
     },
   ]
 

--- a/app/robots-txt-checker/page.tsx
+++ b/app/robots-txt-checker/page.tsx
@@ -1,0 +1,48 @@
+import SeoToolLanding from "@/components/seo-tool-landing"
+import { constructMetadata } from "@/lib/utils"
+import { Metadata } from "next/types"
+
+export const metadata: Metadata = constructMetadata({
+  title: "Free Robots.txt Checker | SeoCheckup",
+  description:
+    "Check and view robots.txt files. Highlight User-agent, Allow, Disallow, and Sitemap directives free.",
+  canonical: "/robots-txt-checker",
+})
+
+export default function RobotsTxtCheckerPage() {
+  return (
+    <SeoToolLanding
+      h1="Free Robots.txt Checker"
+      pitch="Fetch any public robots.txt and highlight User-agent, Allow, Disallow, and Sitemap lines."
+      ctaHref="/robots?q=https://shrix1.com/robots.txt"
+      canonicalPath="/robots-txt-checker"
+      appName="Robots.txt Checker"
+      benefits={[
+        "Load robots.txt from any public site URL",
+        "Highlight crawl directives so rules are easy to scan",
+        "Spot Sitemap lines declared for search engines",
+      ]}
+      faqs={[
+        {
+          question: "Where does robots.txt live?",
+          answer:
+            "It must be at the site root, for example https://example.com/robots.txt. Search engines look there first before crawling.",
+        },
+        {
+          question: "What does the Sitemap directive do?",
+          answer:
+            "A Sitemap line in robots.txt tells crawlers where to find your XML sitemap or sitemap index, so they can discover URLs faster.",
+        },
+        {
+          question: "Does Disallow stop a page from being indexed?",
+          answer:
+            "Disallow asks crawlers not to fetch a URL. Indexing can still happen from links elsewhere. Use noindex meta or headers when you need to keep a page out of results.",
+        },
+      ]}
+      related={[
+        { href: "/sitemap-checker", label: "XML Sitemap Checker" },
+        { href: "/meta-tags-checker", label: "Meta Tags Checker" },
+      ]}
+    />
+  )
+}

--- a/app/robots-txt-checker/page.tsx
+++ b/app/robots-txt-checker/page.tsx
@@ -17,7 +17,9 @@ export default function RobotsTxtCheckerPage() {
     <SeoToolLanding
       h1="Free Robots.txt Checker"
       pitch="Fetch any public robots.txt and highlight User-agent, Allow, Disallow, and Sitemap lines."
-      ctaHref="/robots?q=https://shrix1.com/robots.txt"
+      toolPath="/robots"
+      defaultDemoUrl="https://shrix1.com/robots.txt"
+      inputPlaceholder="https://example.com/robots.txt"
       canonicalPath={feature.landingPath}
       appName={feature.appName}
       blogHref={blogPath(feature.blogSlug)}

--- a/app/robots-txt-checker/page.tsx
+++ b/app/robots-txt-checker/page.tsx
@@ -1,12 +1,15 @@
 import SeoToolLanding from "@/components/seo-tool-landing"
+import { blogPath, features } from "@/lib/site"
 import { constructMetadata } from "@/lib/utils"
 import { Metadata } from "next/types"
+
+const feature = features.robots
 
 export const metadata: Metadata = constructMetadata({
   title: "Free Robots.txt Checker | SeoCheckup",
   description:
-    "Check and view robots.txt files. Highlight User-agent, Allow, Disallow, and Sitemap directives free.",
-  canonical: "/robots-txt-checker",
+    "Check any public robots.txt free. Highlight User-agent, Allow, Disallow, and Sitemap directives so you can confirm crawl rules and avoid blocking important pages by mistake.",
+  canonical: feature.landingPath,
 })
 
 export default function RobotsTxtCheckerPage() {
@@ -15,8 +18,10 @@ export default function RobotsTxtCheckerPage() {
       h1="Free Robots.txt Checker"
       pitch="Fetch any public robots.txt and highlight User-agent, Allow, Disallow, and Sitemap lines."
       ctaHref="/robots?q=https://shrix1.com/robots.txt"
-      canonicalPath="/robots-txt-checker"
-      appName="Robots.txt Checker"
+      canonicalPath={feature.landingPath}
+      appName={feature.appName}
+      blogHref={blogPath(feature.blogSlug)}
+      blogLabel={feature.blogLabel}
       benefits={[
         "Load robots.txt from any public site URL",
         "Highlight crawl directives so rules are easy to scan",
@@ -40,6 +45,7 @@ export default function RobotsTxtCheckerPage() {
         },
       ]}
       related={[
+        { href: "/site-audit", label: "Website SEO Audit" },
         { href: "/sitemap-checker", label: "XML Sitemap Checker" },
         { href: "/meta-tags-checker", label: "Meta Tags Checker" },
       ]}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,3 +1,4 @@
+import { SITE_URL } from "@/lib/site"
 import { MetadataRoute } from "next"
 
 export default function robots(): MetadataRoute.Robots {
@@ -5,8 +6,9 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: "*",
       allow: "/",
-      disallow: "",
+      disallow: ["/api/"],
     },
-    sitemap: "https://seocheckup.vercel.app/sitemap.xml",
+    host: "seocheckup.vercel.app",
+    sitemap: `${SITE_URL}/sitemap.xml`,
   }
 }

--- a/app/site-audit/page.tsx
+++ b/app/site-audit/page.tsx
@@ -17,8 +17,9 @@ export default function SiteAuditLandingPage() {
     <SeoToolLanding
       h1="Free Website SEO Audit"
       pitch="Paste one URL. Get a prioritized checklist across on-page SEO, robots & sitemap, and trust signals — free, with no locked details."
-      ctaHref="/audit?q=https://shrix1.com"
-      ctaLabel="Run free audit"
+      toolPath="/audit"
+      defaultDemoUrl="https://shrix1.com"
+      inputPlaceholder="https://example.com"
       canonicalPath={feature.landingPath}
       appName={feature.appName}
       blogHref={blogPath(feature.blogSlug)}

--- a/app/site-audit/page.tsx
+++ b/app/site-audit/page.tsx
@@ -1,0 +1,50 @@
+import SeoToolLanding from "@/components/seo-tool-landing"
+import { constructMetadata } from "@/lib/utils"
+import { Metadata } from "next/types"
+
+export const metadata: Metadata = constructMetadata({
+  title: "Free Website SEO Audit Tool | SeoCheckup",
+  description:
+    "Run a free website SEO audit: robots.txt, XML sitemap, meta tags, security headers, and Ahrefs Domain Rating in one report.",
+  canonical: "/site-audit",
+})
+
+export default function SiteAuditLandingPage() {
+  return (
+    <SeoToolLanding
+      h1="Free Website SEO Audit"
+      pitch="Paste one URL. Get a prioritized checklist across on-page SEO, robots & sitemap, and trust signals — free, with no locked details."
+      ctaHref="/audit?q=https://shrix1.com"
+      ctaLabel="Run free audit"
+      canonicalPath="/site-audit"
+      appName="Website SEO Audit"
+      benefits={[
+        "On-page checks: title, description, H1, canonical, OG, JSON-LD",
+        "Crawl checks: robots.txt and expandable XML sitemaps",
+        "Trust: HTTPS, security headers, and Ahrefs Domain Rating",
+      ]}
+      faqs={[
+        {
+          question: "What does the free site audit include?",
+          answer:
+            "It checks homepage HTML signals, robots.txt, XML sitemaps, response security headers, and Ahrefs Domain Rating. It does not run Lighthouse or a full site crawl.",
+        },
+        {
+          question: "Is every check unlocked?",
+          answer:
+            "Yes. Every pass, warning, and fail shows real values and a short fix hint — nothing is paywalled.",
+        },
+        {
+          question: "Can I open specialized tools from the report?",
+          answer:
+            "Yes. Many findings deep-link into the Sitemap, Metadata, Robots, or Domain Rating tools with your URL prefilled.",
+        },
+      ]}
+      related={[
+        { href: "/domain-rating-checker", label: "Domain Rating Checker" },
+        { href: "/sitemap-checker", label: "XML Sitemap Checker" },
+        { href: "/meta-tags-checker", label: "Meta Tags Checker" },
+      ]}
+    />
+  )
+}

--- a/app/site-audit/page.tsx
+++ b/app/site-audit/page.tsx
@@ -1,12 +1,15 @@
 import SeoToolLanding from "@/components/seo-tool-landing"
+import { blogPath, features } from "@/lib/site"
 import { constructMetadata } from "@/lib/utils"
 import { Metadata } from "next/types"
+
+const feature = features.audit
 
 export const metadata: Metadata = constructMetadata({
   title: "Free Website SEO Audit Tool | SeoCheckup",
   description:
-    "Run a free website SEO audit: robots.txt, XML sitemap, meta tags, security headers, and Ahrefs Domain Rating in one report.",
-  canonical: "/site-audit",
+    "Run a free website SEO audit without an account: robots.txt, expandable XML sitemaps, on-page meta tags, security headers, and Ahrefs Domain Rating in one prioritized report.",
+  canonical: feature.landingPath,
 })
 
 export default function SiteAuditLandingPage() {
@@ -16,8 +19,10 @@ export default function SiteAuditLandingPage() {
       pitch="Paste one URL. Get a prioritized checklist across on-page SEO, robots & sitemap, and trust signals — free, with no locked details."
       ctaHref="/audit?q=https://shrix1.com"
       ctaLabel="Run free audit"
-      canonicalPath="/site-audit"
-      appName="Website SEO Audit"
+      canonicalPath={feature.landingPath}
+      appName={feature.appName}
+      blogHref={blogPath(feature.blogSlug)}
+      blogLabel={feature.blogLabel}
       benefits={[
         "On-page checks: title, description, H1, canonical, OG, JSON-LD",
         "Crawl checks: robots.txt and expandable XML sitemaps",

--- a/app/sitemap-checker/page.tsx
+++ b/app/sitemap-checker/page.tsx
@@ -17,7 +17,9 @@ export default function SitemapCheckerPage() {
     <SeoToolLanding
       h1="Free XML Sitemap Checker"
       pitch="Expand sitemap indexes, list every page URL, then copy or filter by child sitemap."
-      ctaHref="/sitemap?q=https://shrix1.com/sitemap.xml"
+      toolPath="/sitemap"
+      defaultDemoUrl="https://shrix1.com/sitemap.xml"
+      inputPlaceholder="https://example.com/sitemap.xml"
       canonicalPath={feature.landingPath}
       appName={feature.appName}
       blogHref={blogPath(feature.blogSlug)}

--- a/app/sitemap-checker/page.tsx
+++ b/app/sitemap-checker/page.tsx
@@ -1,12 +1,15 @@
 import SeoToolLanding from "@/components/seo-tool-landing"
+import { blogPath, features } from "@/lib/site"
 import { constructMetadata } from "@/lib/utils"
 import { Metadata } from "next/types"
+
+const feature = features.sitemap
 
 export const metadata: Metadata = constructMetadata({
   title: "Free XML Sitemap Checker | SeoCheckup",
   description:
-    "Check and expand XML sitemaps and sitemap indexes. List every URL, filter by child sitemap, and copy results free.",
-  canonical: "/sitemap-checker",
+    "Validate and expand XML sitemaps and sitemap indexes free. Follow child sitemaps automatically, list every page URL, filter by source file, and copy the full URL list in one click.",
+  canonical: feature.landingPath,
 })
 
 export default function SitemapCheckerPage() {
@@ -15,8 +18,10 @@ export default function SitemapCheckerPage() {
       h1="Free XML Sitemap Checker"
       pitch="Expand sitemap indexes, list every page URL, then copy or filter by child sitemap."
       ctaHref="/sitemap?q=https://shrix1.com/sitemap.xml"
-      canonicalPath="/sitemap-checker"
-      appName="XML Sitemap Checker"
+      canonicalPath={feature.landingPath}
+      appName={feature.appName}
+      blogHref={blogPath(feature.blogSlug)}
+      blogLabel={feature.blogLabel}
       benefits={[
         "Follows sitemap indexes into child sitemaps automatically",
         "Filter URLs by source child sitemap when you have an index",
@@ -40,6 +45,7 @@ export default function SitemapCheckerPage() {
         },
       ]}
       related={[
+        { href: "/site-audit", label: "Website SEO Audit" },
         { href: "/meta-tags-checker", label: "Meta Tags Checker" },
         { href: "/robots-txt-checker", label: "Robots.txt Checker" },
       ]}

--- a/app/sitemap-checker/page.tsx
+++ b/app/sitemap-checker/page.tsx
@@ -1,0 +1,48 @@
+import SeoToolLanding from "@/components/seo-tool-landing"
+import { constructMetadata } from "@/lib/utils"
+import { Metadata } from "next/types"
+
+export const metadata: Metadata = constructMetadata({
+  title: "Free XML Sitemap Checker | SeoCheckup",
+  description:
+    "Check and expand XML sitemaps and sitemap indexes. List every URL, filter by child sitemap, and copy results free.",
+  canonical: "/sitemap-checker",
+})
+
+export default function SitemapCheckerPage() {
+  return (
+    <SeoToolLanding
+      h1="Free XML Sitemap Checker"
+      pitch="Expand sitemap indexes, list every page URL, then copy or filter by child sitemap."
+      ctaHref="/sitemap?q=https://shrix1.com/sitemap.xml"
+      canonicalPath="/sitemap-checker"
+      appName="XML Sitemap Checker"
+      benefits={[
+        "Follows sitemap indexes into child sitemaps automatically",
+        "Filter URLs by source child sitemap when you have an index",
+        "Copy the full URL list in one click",
+      ]}
+      faqs={[
+        {
+          question: "What is a sitemap index?",
+          answer:
+            "A sitemap index is an XML file that lists other sitemaps instead of page URLs. Large sites use indexes to split URLs across multiple sitemap files.",
+        },
+        {
+          question: "Does this checker follow child sitemaps?",
+          answer:
+            "Yes. When you paste a sitemap index URL, SeoCheckup expands nested child sitemaps and returns the page URLs they contain.",
+        },
+        {
+          question: "Is the XML Sitemap Checker free?",
+          answer:
+            "Yes. You can check any public sitemap URL at no cost, with no account required.",
+        },
+      ]}
+      related={[
+        { href: "/meta-tags-checker", label: "Meta Tags Checker" },
+        { href: "/robots-txt-checker", label: "Robots.txt Checker" },
+      ]}
+    />
+  )
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,12 +2,20 @@ import { MetadataRoute } from "next"
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = "https://seocheckup.vercel.app"
-  const pages = ["/", "/sitemap", "/metadata", "/robots"] as const
+  const pages: { path: string; priority: number }[] = [
+    { path: "/", priority: 1 },
+    { path: "/sitemap-checker", priority: 0.9 },
+    { path: "/meta-tags-checker", priority: 0.9 },
+    { path: "/robots-txt-checker", priority: 0.9 },
+    { path: "/sitemap", priority: 0.8 },
+    { path: "/metadata", priority: 0.8 },
+    { path: "/robots", priority: 0.8 },
+  ]
 
-  return pages.map((page) => ({
-    url: new URL(page, baseUrl).toString(),
+  return pages.map(({ path, priority }) => ({
+    url: new URL(path, baseUrl).toString(),
     lastModified: new Date(),
     changeFrequency: "monthly" as const,
-    priority: page === "/" ? 1 : 0.8,
+    priority,
   }))
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,31 +1,37 @@
+import { blogMetadata, blogSlugs } from "@/lib/blog-metadata"
+import { SITE_URL, features } from "@/lib/site"
 import { MetadataRoute } from "next"
-import { blogSlugs } from "@/lib/blog-metadata"
+
+const STABLE_DATE = new Date("2026-07-15")
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = "https://seocheckup.vercel.app"
-  const pages: { path: string; priority: number }[] = [
+  const staticPages: { path: string; priority: number }[] = [
     { path: "/", priority: 1 },
-    { path: "/site-audit", priority: 0.95 },
-    { path: "/domain-rating-checker", priority: 0.9 },
-    { path: "/sitemap-checker", priority: 0.9 },
-    { path: "/meta-tags-checker", priority: 0.9 },
-    { path: "/robots-txt-checker", priority: 0.9 },
-    { path: "/audit", priority: 0.85 },
-    { path: "/domain-rating", priority: 0.85 },
-    { path: "/sitemap", priority: 0.8 },
-    { path: "/metadata", priority: 0.8 },
-    { path: "/robots", priority: 0.8 },
+    { path: features.audit.landingPath, priority: 0.95 },
+    { path: features.domainRating.landingPath, priority: 0.9 },
+    { path: features.sitemap.landingPath, priority: 0.9 },
+    { path: features.metadata.landingPath, priority: 0.9 },
+    { path: features.robots.landingPath, priority: 0.9 },
+    { path: features.audit.toolPath, priority: 0.85 },
+    { path: features.domainRating.toolPath, priority: 0.85 },
+    { path: features.sitemap.toolPath, priority: 0.8 },
+    { path: features.metadata.toolPath, priority: 0.8 },
+    { path: features.robots.toolPath, priority: 0.8 },
     { path: "/blog", priority: 0.75 },
+  ]
+
+  return [
+    ...staticPages.map(({ path, priority }) => ({
+      url: new URL(path, SITE_URL).toString(),
+      lastModified: STABLE_DATE,
+      changeFrequency: "monthly" as const,
+      priority,
+    })),
     ...blogSlugs.map((slug) => ({
-      path: `/blog/${slug}`,
+      url: new URL(`/blog/${slug}`, SITE_URL).toString(),
+      lastModified: new Date(blogMetadata[slug].date),
+      changeFrequency: "monthly" as const,
       priority: 0.7,
     })),
   ]
-
-  return pages.map(({ path, priority }) => ({
-    url: new URL(path, baseUrl).toString(),
-    lastModified: new Date(),
-    changeFrequency: "monthly" as const,
-    priority,
-  }))
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,15 +1,25 @@
 import { MetadataRoute } from "next"
+import { blogSlugs } from "@/lib/blog-metadata"
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = "https://seocheckup.vercel.app"
   const pages: { path: string; priority: number }[] = [
     { path: "/", priority: 1 },
+    { path: "/site-audit", priority: 0.95 },
+    { path: "/domain-rating-checker", priority: 0.9 },
     { path: "/sitemap-checker", priority: 0.9 },
     { path: "/meta-tags-checker", priority: 0.9 },
     { path: "/robots-txt-checker", priority: 0.9 },
+    { path: "/audit", priority: 0.85 },
+    { path: "/domain-rating", priority: 0.85 },
     { path: "/sitemap", priority: 0.8 },
     { path: "/metadata", priority: 0.8 },
     { path: "/robots", priority: 0.8 },
+    { path: "/blog", priority: 0.75 },
+    ...blogSlugs.map((slug) => ({
+      path: `/blog/${slug}`,
+      priority: 0.7,
+    })),
   ]
 
   return pages.map(({ path, priority }) => ({

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,12 +2,12 @@ import { MetadataRoute } from "next"
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = "https://seocheckup.vercel.app"
-  const pages = ["/", "/sitemap", "metadata"]
+  const pages = ["/", "/sitemap", "/metadata", "/robots"] as const
 
   return pages.map((page) => ({
-    url: `${baseUrl}${page}`,
+    url: new URL(page, baseUrl).toString(),
     lastModified: new Date(),
     changeFrequency: "monthly" as const,
-    priority: 1,
+    priority: page === "/" ? 1 : 0.8,
   }))
 }

--- a/components/blog-explorer.tsx
+++ b/components/blog-explorer.tsx
@@ -1,10 +1,22 @@
 "use client"
 
 import { getBlogPosts } from "@/lib/blog-metadata"
+import { features } from "@/lib/site"
 import Link from "next/link"
 import { useMemo, useState } from "react"
 
 const posts = getBlogPosts()
+
+const toolLinks = [
+  features.audit,
+  features.domainRating,
+  features.sitemap,
+  features.metadata,
+  features.robots,
+].map((f) => ({
+  href: f.landingPath,
+  label: f.landingLabel,
+}))
 
 export default function BlogExplorer() {
   const [query, setQuery] = useState("")
@@ -30,17 +42,15 @@ export default function BlogExplorer() {
 
   return (
     <div className="w-full max-w-5xl mx-auto px-4 py-12 md:py-16">
-      <div className="text-center">
-        <h1 className="text-4xl sm:text-5xl font-bold font-mono tracking-tight">
-          Blog
-        </h1>
-        <p className="mt-3 text-muted-foreground max-w-xl mx-auto">
-          Practical guides for sitemaps, meta tags, robots.txt, Domain Rating, and
-          free site audits.
-        </p>
-      </div>
+      <h1 className="text-4xl sm:text-5xl font-bold font-mono tracking-tight">
+        Blog
+      </h1>
+      <p className="mt-3 text-muted-foreground max-w-xl">
+        Practical guides for sitemaps, meta tags, robots.txt, Domain Rating, and
+        free site audits.
+      </p>
 
-      <div className="mt-8 flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-center">
+      <div className="mt-8 flex flex-col sm:flex-row gap-3 sm:items-center">
         <input
           value={query}
           onChange={(e) => setQuery(e.target.value)}
@@ -48,7 +58,7 @@ export default function BlogExplorer() {
           className="flex h-9 w-full sm:max-w-xs rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           aria-label="Search blog posts"
         />
-        <div className="flex flex-wrap gap-2 justify-center">
+        <div className="flex flex-wrap gap-2">
           {categories.map((cat) => (
             <button
               key={cat}
@@ -96,6 +106,27 @@ export default function BlogExplorer() {
       {filtered.length === 0 && (
         <p className="mt-10 text-sm text-muted-foreground">No posts matched.</p>
       )}
+
+      <nav
+        aria-label="SEO tools"
+        className="mt-16 pt-8 border-t text-sm text-muted-foreground"
+      >
+        <p className="font-medium text-foreground">Free tools</p>
+        <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2">
+          <Link href="/" className="underline underline-offset-2 hover:text-foreground">
+            Home
+          </Link>
+          {toolLinks.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="underline underline-offset-2 hover:text-foreground"
+            >
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      </nav>
     </div>
   )
 }

--- a/components/blog-explorer.tsx
+++ b/components/blog-explorer.tsx
@@ -30,15 +30,17 @@ export default function BlogExplorer() {
 
   return (
     <div className="w-full max-w-5xl mx-auto px-4 py-12 md:py-16">
-      <h1 className="text-4xl sm:text-5xl font-bold font-mono tracking-tight">
-        Blog
-      </h1>
-      <p className="mt-3 text-muted-foreground max-w-xl">
-        Practical guides for sitemaps, meta tags, robots.txt, Domain Rating, and
-        free site audits.
-      </p>
+      <div className="text-center">
+        <h1 className="text-4xl sm:text-5xl font-bold font-mono tracking-tight">
+          Blog
+        </h1>
+        <p className="mt-3 text-muted-foreground max-w-xl mx-auto">
+          Practical guides for sitemaps, meta tags, robots.txt, Domain Rating, and
+          free site audits.
+        </p>
+      </div>
 
-      <div className="mt-8 flex flex-col sm:flex-row gap-3 sm:items-center">
+      <div className="mt-8 flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-center">
         <input
           value={query}
           onChange={(e) => setQuery(e.target.value)}
@@ -46,7 +48,7 @@ export default function BlogExplorer() {
           className="flex h-9 w-full sm:max-w-xs rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           aria-label="Search blog posts"
         />
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-2 justify-center">
           {categories.map((cat) => (
             <button
               key={cat}

--- a/components/blog-explorer.tsx
+++ b/components/blog-explorer.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import { getBlogPosts } from "@/lib/blog-metadata"
+import Link from "next/link"
+import { useMemo, useState } from "react"
+
+const posts = getBlogPosts()
+
+export default function BlogExplorer() {
+  const [query, setQuery] = useState("")
+  const [category, setCategory] = useState<string>("All")
+
+  const categories = useMemo(() => {
+    const set = new Set(posts.map((p) => p.category))
+    return ["All", ...Array.from(set)]
+  }, [])
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return posts.filter((p) => {
+      if (category !== "All" && p.category !== category) return false
+      if (!q) return true
+      return (
+        p.title.toLowerCase().includes(q) ||
+        p.description.toLowerCase().includes(q) ||
+        p.category.toLowerCase().includes(q)
+      )
+    })
+  }, [query, category])
+
+  return (
+    <div className="w-full max-w-5xl mx-auto px-4 py-12 md:py-16">
+      <h1 className="text-4xl sm:text-5xl font-bold font-mono tracking-tight">
+        Blog
+      </h1>
+      <p className="mt-3 text-muted-foreground max-w-xl">
+        Practical guides for sitemaps, meta tags, robots.txt, Domain Rating, and
+        free site audits.
+      </p>
+
+      <div className="mt-8 flex flex-col sm:flex-row gap-3 sm:items-center">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search posts…"
+          className="flex h-9 w-full sm:max-w-xs rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          aria-label="Search blog posts"
+        />
+        <div className="flex flex-wrap gap-2">
+          {categories.map((cat) => (
+            <button
+              key={cat}
+              type="button"
+              onClick={() => setCategory(cat)}
+              className={
+                category === cat
+                  ? "text-xs font-medium px-2.5 py-1 rounded-md bg-foreground text-background"
+                  : "text-xs font-medium px-2.5 py-1 rounded-md border hover:bg-accent"
+              }
+            >
+              {cat}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-10 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+        {filtered.map((post) => (
+          <Link
+            key={post.slug}
+            href={`/blog/${post.slug}`}
+            className="group border rounded-xl overflow-hidden hover:shadow-md transition-shadow bg-background"
+          >
+            <div
+              className="aspect-[16/10] bg-muted bg-cover bg-center"
+              style={{ backgroundImage: `url(${post.coverImage})` }}
+            />
+            <div className="p-4">
+              <p className="text-xs font-mono text-muted-foreground">
+                {post.category} · {post.date}
+              </p>
+              <h2 className="mt-2 font-semibold group-hover:underline underline-offset-2 line-clamp-2">
+                {post.title}
+              </h2>
+              <p className="mt-2 text-sm text-muted-foreground line-clamp-3">
+                {post.description}
+              </p>
+              <p className="mt-3 text-xs text-muted-foreground">{post.readTime}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+
+      {filtered.length === 0 && (
+        <p className="mt-10 text-sm text-muted-foreground">No posts matched.</p>
+      )}
+    </div>
+  )
+}

--- a/components/buy-me-coffee.tsx
+++ b/components/buy-me-coffee.tsx
@@ -2,9 +2,12 @@
 
 import { useState, useEffect } from "react"
 import { Coffee, X } from "lucide-react"
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion"
+import { easeOut } from "@/components/motion"
 
 export default function BuyMeCoffee() {
   const [showMessage, setShowMessage] = useState(false)
+  const reduceMotion = useReducedMotion()
 
   useEffect(() => {
     const dismissed = localStorage.getItem("bmc-dismissed")
@@ -23,31 +26,41 @@ export default function BuyMeCoffee() {
 
   return (
     <div className="fixed bottom-5 right-5 z-50 flex items-center gap-2">
-      {showMessage && (
-        <div className="flex items-center gap-2 bg-white dark:bg-zinc-800 rounded-2xl shadow-lg pl-4 pr-2 py-3">
-          <a
-            href="https://www.buymeacoffee.com/shrix1"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm text-zinc-700 dark:text-zinc-300 hover:text-zinc-900 dark:hover:text-zinc-100"
+      <AnimatePresence>
+        {showMessage && (
+          <motion.div
+            initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={reduceMotion ? undefined : { opacity: 0, y: 8 }}
+            transition={{ duration: 0.25, ease: easeOut }}
+            className="flex items-center gap-2 bg-white dark:bg-zinc-800 rounded-2xl shadow-lg pl-4 pr-2 py-3"
           >
-            <span className="font-medium">Hi, I&apos;m Shri 👋</span>
-            <br />
-            If this site helped you, support me here!
-          </a>
-          <button
-            onClick={handleClose}
-            className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 p-1"
-          >
-            <X className="w-4 h-4" />
-          </button>
-        </div>
-      )}
+            <a
+              href="https://www.buymeacoffee.com/shrix1"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-zinc-700 dark:text-zinc-300 hover:text-zinc-900 dark:hover:text-zinc-100"
+            >
+              <span className="font-medium">Hi, I&apos;m Shri</span>
+              <br />
+              If this site helped you, support me here!
+            </a>
+            <button
+              onClick={handleClose}
+              className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 p-1"
+              aria-label="Dismiss support message"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </motion.div>
+        )}
+      </AnimatePresence>
       <a
         href="https://www.buymeacoffee.com/shrix1"
         target="_blank"
         rel="noopener noreferrer"
-        className="bg-[#FFDD00] hover:bg-[#FFDD00]/90 p-3 rounded-full shadow-lg transition-all hover:scale-110"
+        className="bg-[#FFDD00] hover:bg-[#FFDD00]/90 p-3 rounded-full shadow-lg transition-transform duration-[var(--duration-fast)] ease-[var(--ease-out)] hover:scale-110"
+        aria-label="Buy me a coffee"
       >
         <Coffee className="w-6 h-6 text-black" />
       </a>

--- a/components/home-hero.tsx
+++ b/components/home-hero.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import ToolCard from "@/components/tool-card"
+import { FadeIn, StaggerChildren, StaggerItem } from "@/components/motion"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+
+const DEMO = "https://shrix1.com"
+
+const tools = [
+  {
+    id: 1,
+    title: "Sitemap Link Checker",
+    content: "Easily review your sitemap by adding yoursite.com/sitemap.xml.",
+    link: "/sitemap-checker",
+  },
+  {
+    id: 2,
+    title: "Metadata viewer",
+    content: "Easily review your metadata by adding your site link.",
+    link: "/meta-tags-checker",
+  },
+  {
+    id: 3,
+    title: "Robots.txt Viewer",
+    content: "Inspect robots.txt directives, sitemaps, and crawl rules.",
+    link: "/robots-txt-checker",
+  },
+  {
+    id: 4,
+    title: "Domain Rating",
+    content: "Check Ahrefs Domain Rating for any domain — free.",
+    link: "/domain-rating-checker",
+  },
+]
+
+export default function HomeHero() {
+  const router = useRouter()
+  const [url, setUrl] = useState(DEMO)
+
+  return (
+    <section className="relative flex justify-center flex-col items-center min-h-[83vh]">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10 bg-background
+          bg-[linear-gradient(to_right,hsl(var(--border))_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--border))_1px,transparent_1px)]
+          bg-[size:6rem_4rem]
+          [mask-image:radial-gradient(ellipse_70%_60%_at_50%_30%,black,transparent)]"
+      />
+
+      <main className="flex justify-center flex-col items-center w-full px-4 py-16 md:py-24">
+        <FadeIn className="flex flex-col items-center text-center max-w-2xl w-full">
+          <h1 className="text-5xl sm:text-6xl md:text-7xl font-bold tracking-tight font-mono">
+            SeoCheckup
+          </h1>
+          <p className="mt-4 text-base sm:text-lg text-muted-foreground max-w-md">
+            Free site audit for sitemaps, metadata, robots.txt, and Domain Rating.
+          </p>
+
+          <form
+            className="mt-8 flex flex-col sm:flex-row gap-2 w-full max-w-lg"
+            onSubmit={(e) => {
+              e.preventDefault()
+              const q = url.trim() || DEMO
+              router.push(`/audit?q=${encodeURIComponent(q)}`)
+            }}
+          >
+            <Input
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://example.com"
+              className="font-mono"
+              aria-label="URL to audit"
+            />
+            <Button type="submit" size="lg" className="shrink-0">
+              Run free audit
+            </Button>
+          </form>
+          <p className="mt-3 text-xs text-muted-foreground">
+            Or{" "}
+            <Link href="/site-audit" className="underline underline-offset-2">
+              learn about the audit
+            </Link>
+            {" · "}
+            <Link href="/blog" className="underline underline-offset-2">
+              Blog
+            </Link>
+          </p>
+        </FadeIn>
+
+        <StaggerChildren className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-14 w-full max-w-5xl">
+          {tools.map((tool) => (
+            <StaggerItem key={tool.id}>
+              <ToolCard
+                title={tool.title}
+                content={tool.content}
+                link={tool.link}
+              />
+            </StaggerItem>
+          ))}
+        </StaggerChildren>
+      </main>
+    </section>
+  )
+}

--- a/components/home-hero.tsx
+++ b/components/home-hero.tsx
@@ -62,8 +62,9 @@ export default function HomeHero() {
           <h1 className="text-5xl sm:text-6xl md:text-7xl font-bold tracking-tight font-mono">
             SeoCheckup
           </h1>
-          <p className="mt-4 text-base sm:text-lg text-muted-foreground max-w-md">
-            Free site audit for sitemaps, metadata, robots.txt, and Domain Rating.
+          <p className="mt-4 text-base sm:text-lg text-muted-foreground max-w-xl">
+            Free site audit for any website — check sitemap, meta tags,
+            robots.txt, and Domain Rating in one go.
           </p>
 
           <form

--- a/components/home-hero.tsx
+++ b/components/home-hero.tsx
@@ -12,6 +12,12 @@ const DEMO = "https://shrix1.com"
 
 const tools = [
   {
+    id: 0,
+    title: "Site Audit",
+    content: "One URL for on-page, robots, sitemap, headers, and Domain Rating.",
+    link: "/site-audit",
+  },
+  {
     id: 1,
     title: "Sitemap Link Checker",
     content: "Easily review your sitemap by adding yoursite.com/sitemap.xml.",
@@ -91,7 +97,7 @@ export default function HomeHero() {
           </p>
         </FadeIn>
 
-        <StaggerChildren className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-14 w-full max-w-5xl">
+        <StaggerChildren className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-14 w-full max-w-5xl">
           {tools.map((tool) => (
             <StaggerItem key={tool.id}>
               <ToolCard

--- a/components/json-ld.tsx
+++ b/components/json-ld.tsx
@@ -1,0 +1,13 @@
+type JsonLdProps = {
+  data: Record<string, unknown> | Record<string, unknown>[]
+}
+
+/** Safe schema.org JSON-LD script tag */
+export default function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  )
+}

--- a/components/motion.tsx
+++ b/components/motion.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import { motion, useReducedMotion, type HTMLMotionProps } from "framer-motion"
+import type { ReactNode } from "react"
+
+const easeOut = [0.23, 1, 0.32, 1] as const
+
+export function FadeIn({
+  children,
+  className,
+  delay = 0,
+  ...props
+}: {
+  children: ReactNode
+  className?: string
+  delay?: number
+} & HTMLMotionProps<"div">) {
+  const reduceMotion = useReducedMotion()
+
+  if (reduceMotion) {
+    return <div className={className}>{children}</div>
+  }
+
+  return (
+    <motion.div
+      className={className}
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, delay, ease: easeOut }}
+      {...props}
+    >
+      {children}
+    </motion.div>
+  )
+}
+
+export function StaggerChildren({
+  children,
+  className,
+  stagger = 0.08,
+}: {
+  children: ReactNode
+  className?: string
+  stagger?: number
+}) {
+  const reduceMotion = useReducedMotion()
+
+  if (reduceMotion) {
+    return <div className={className}>{children}</div>
+  }
+
+  return (
+    <motion.div
+      className={className}
+      initial="hidden"
+      animate="show"
+      variants={{
+        hidden: {},
+        show: {
+          transition: { staggerChildren: stagger },
+        },
+      }}
+    >
+      {children}
+    </motion.div>
+  )
+}
+
+export function StaggerItem({
+  children,
+  className,
+}: {
+  children: ReactNode
+  className?: string
+}) {
+  const reduceMotion = useReducedMotion()
+
+  if (reduceMotion) {
+    return <div className={className}>{children}</div>
+  }
+
+  return (
+    <motion.div
+      className={className}
+      variants={{
+        hidden: { opacity: 0, y: 10 },
+        show: {
+          opacity: 1,
+          y: 0,
+          transition: { duration: 0.25, ease: easeOut },
+        },
+      }}
+    >
+      {children}
+    </motion.div>
+  )
+}
+
+export { motion, useReducedMotion, easeOut }

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -71,7 +71,7 @@ const Navbar = () => {
         <Link
           href="/blog"
           className={cn(
-            "hidden md:inline text-sm font-medium px-2 py-1 rounded-md hover:bg-accent",
+            "text-sm font-medium px-2 py-1 rounded-md hover:bg-accent",
             pathname.startsWith("/blog") && "underline underline-offset-4"
           )}
         >

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -11,17 +11,17 @@ import { ThemeSwitcher } from "./theme"
 const tools = [
   {
     label: "Sitemap",
-    href: "/sitemap?q=https://supwriter.com/sitemap.xml",
+    href: "/sitemap?q=https://shrix1.com/sitemap.xml",
     match: "/sitemap",
   },
   {
     label: "Metadata",
-    href: "/metadata?q=https://supwriter.com",
+    href: "/metadata?q=https://shrix1.com",
     match: "/metadata",
   },
   {
     label: "Robots",
-    href: "/robots?q=https://supwriter.com/robots.txt",
+    href: "/robots?q=https://shrix1.com/robots.txt",
     match: "/robots",
   },
 ] as const

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -10,6 +10,16 @@ import { ThemeSwitcher } from "./theme"
 
 const tools = [
   {
+    label: "Audit",
+    href: "/audit?q=https://shrix1.com",
+    match: "/audit",
+  },
+  {
+    label: "DR",
+    href: "/domain-rating?q=https://shrix1.com",
+    match: "/domain-rating",
+  },
+  {
     label: "Sitemap",
     href: "/sitemap?q=https://shrix1.com/sitemap.xml",
     match: "/sitemap",
@@ -41,13 +51,13 @@ const Navbar = () => {
             SeoCheckup
           </h2>
         </Link>
-        <div className="flex items-center gap-1 sm:gap-3 text-sm font-medium">
+        <div className="flex items-center gap-1 sm:gap-2 text-sm font-medium overflow-x-auto max-w-[55vw] sm:max-w-none">
           {tools.map((tool) => (
             <Link
               key={tool.match}
               href={tool.href}
               className={cn(
-                "px-1.5 sm:px-2 py-1 rounded-md transition-colors hover:bg-accent hover:text-accent-foreground",
+                "px-1.5 sm:px-2 py-1 rounded-md transition-colors hover:bg-accent hover:text-accent-foreground whitespace-nowrap",
                 pathname === tool.match && "underline underline-offset-4"
               )}
             >
@@ -58,6 +68,15 @@ const Navbar = () => {
       </div>
 
       <div className="flex items-center gap-1 sm:gap-2 shrink-0">
+        <Link
+          href="/blog"
+          className={cn(
+            "hidden md:inline text-sm font-medium px-2 py-1 rounded-md hover:bg-accent",
+            pathname.startsWith("/blog") && "underline underline-offset-4"
+          )}
+        >
+          Blog
+        </Link>
         <Link
           href="https://x.com/shribuilds"
           target="_blank"

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,7 +1,19 @@
 "use client"
+
 import Link from "next/link"
 import React from "react"
 import { Flame, Github, Twitter } from "lucide-react"
+import { cn } from "@/lib/utils"
+import {
+  NavigationMenu,
+  NavigationMenuContent,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  NavigationMenuTrigger,
+} from "@/components/ui/navigation-menu"
+import { Button } from "./ui/button"
+import { ThemeSwitcher } from "./theme"
 
 const Navbar = () => {
   return (
@@ -11,9 +23,9 @@ const Navbar = () => {
     >
       <div className="flex items-center gap-2">
         <Link href="/" className="flex items-center gap-2 justify-center group">
-          <Flame className="group-hover:scale-125 transition-all duration-300" />
+          <Flame className="group-hover:scale-125 transition-all duration-[var(--duration-normal)] ease-[var(--ease-out)]" />
           <h2 className="font-medium text-lg group-hover:underline mt-0.5 font-mono">
-            SEO Checkup
+            SeoCheckup
           </h2>
         </Link>
         <div className="hidden md:flex">
@@ -50,18 +62,6 @@ const Navbar = () => {
 
 export default Navbar
 
-import { cn } from "@/lib/utils"
-import {
-  NavigationMenu,
-  NavigationMenuContent,
-  NavigationMenuItem,
-  NavigationMenuLink,
-  NavigationMenuList,
-  NavigationMenuTrigger,
-} from "@/components/ui/navigation-menu"
-import { Button } from "./ui/button"
-import { ThemeSwitcher } from "./theme"
-
 export function NavigationMenuDemo() {
   return (
     <NavigationMenu>
@@ -74,18 +74,18 @@ export function NavigationMenuDemo() {
             <ul className="grid gap-3 p-4 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
               <li className="row-span-3">
                 <NavigationMenuLink asChild>
-                  <a
+                  <Link
                     className="flex h-full w-full select-none flex-col justify-end rounded-md bg-gradient-to-b from-muted/50 to-muted p-6 no-underline outline-none focus:shadow-md"
                     href="/"
                   >
                     <Flame className="h-6 w-6" />
                     <div className="mb-2 mt-4 text-lg font-medium font-mono ">
-                      SEO Checkup
+                      SeoCheckup
                     </div>
                     <p className="text-sm leading-tight text-muted-foreground">
-                      SEO tools for Developers and marketers
+                      SEO tools for developers and marketers
                     </p>
-                  </a>
+                  </Link>
                 </NavigationMenuLink>
               </li>
               <ListItem
@@ -102,8 +102,11 @@ export function NavigationMenuDemo() {
                 Easily review all website meta tags by adding your link:
                 yoursite.com.
               </ListItem>
-              <ListItem href="/" title="More coming soon">
-                More SEO tools coming soon...
+              <ListItem
+                href="/robots?q=https://freetoolsfr.com/robots.txt"
+                title="Robots.txt"
+              >
+                Inspect robots.txt directives, sitemaps, and crawl rules.
               </ListItem>
             </ul>
           </NavigationMenuContent>
@@ -116,12 +119,13 @@ export function NavigationMenuDemo() {
 const ListItem = React.forwardRef<
   React.ElementRef<"a">,
   React.ComponentPropsWithoutRef<"a">
->(({ className, title, children, ...props }, ref) => {
+>(({ className, title, children, href, ...props }, ref) => {
   return (
     <li>
       <NavigationMenuLink asChild>
-        <a
+        <Link
           ref={ref}
+          href={href || "/"}
           className={cn(
             "block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
             className
@@ -134,7 +138,7 @@ const ListItem = React.forwardRef<
           <p className="text-sm leading-snug text-muted-foreground ">
             {children}
           </p>
-        </a>
+        </Link>
       </NavigationMenuLink>
     </li>
   )

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -3,37 +3,61 @@
 import Link from "next/link"
 import React from "react"
 import { Flame, Github, Twitter } from "lucide-react"
+import { usePathname } from "next/navigation"
 import { cn } from "@/lib/utils"
-import {
-  NavigationMenu,
-  NavigationMenuContent,
-  NavigationMenuItem,
-  NavigationMenuLink,
-  NavigationMenuList,
-  NavigationMenuTrigger,
-} from "@/components/ui/navigation-menu"
 import { Button } from "./ui/button"
 import { ThemeSwitcher } from "./theme"
 
+const tools = [
+  {
+    label: "Sitemap",
+    href: "/sitemap?q=https://supwriter.com/sitemap.xml",
+    match: "/sitemap",
+  },
+  {
+    label: "Metadata",
+    href: "/metadata?q=https://supwriter.com",
+    match: "/metadata",
+  },
+  {
+    label: "Robots",
+    href: "/robots?q=https://supwriter.com/robots.txt",
+    match: "/robots",
+  },
+] as const
+
 const Navbar = () => {
+  const pathname = usePathname()
+
   return (
     <nav
-      className="h-[8vh] sticky top-0 text-black dark:text-white w-full px-4 md:px-12 border dark:border-gray-50/10 rounded-lg flex 
-    justify-between items-center backdrop-blur-lg bg-white/80 dark:bg-black/80"
+      className="h-[8vh] sticky top-0 text-black dark:text-white w-full px-3 sm:px-4 md:px-12 border dark:border-gray-50/10 rounded-lg flex 
+    justify-between items-center gap-2 backdrop-blur-lg bg-white/80 dark:bg-black/80"
     >
-      <div className="flex items-center gap-2">
-        <Link href="/" className="flex items-center gap-2 justify-center group">
+      <div className="flex items-center gap-2 sm:gap-4 min-w-0">
+        <Link href="/" className="flex items-center gap-2 justify-center group shrink-0">
           <Flame className="group-hover:scale-125 transition-all duration-[var(--duration-normal)] ease-[var(--ease-out)]" />
-          <h2 className="font-medium text-lg group-hover:underline mt-0.5 font-mono">
+          <h2 className="font-medium text-lg group-hover:underline mt-0.5 font-mono hidden sm:block">
             SeoCheckup
           </h2>
         </Link>
-        <div className="hidden md:flex">
-          <NavigationMenuDemo />
+        <div className="flex items-center gap-1 sm:gap-3 text-sm font-medium">
+          {tools.map((tool) => (
+            <Link
+              key={tool.match}
+              href={tool.href}
+              className={cn(
+                "px-1.5 sm:px-2 py-1 rounded-md transition-colors hover:bg-accent hover:text-accent-foreground",
+                pathname === tool.match && "underline underline-offset-4"
+              )}
+            >
+              {tool.label}
+            </Link>
+          ))}
         </div>
       </div>
 
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1 sm:gap-2 shrink-0">
         <Link
           href="https://x.com/shribuilds"
           target="_blank"
@@ -61,86 +85,3 @@ const Navbar = () => {
 }
 
 export default Navbar
-
-export function NavigationMenuDemo() {
-  return (
-    <NavigationMenu>
-      <NavigationMenuList>
-        <NavigationMenuItem>
-          <NavigationMenuTrigger className="text-base bg-transparent">
-            Tools
-          </NavigationMenuTrigger>
-          <NavigationMenuContent className="!border !border-gray-100/10">
-            <ul className="grid gap-3 p-4 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
-              <li className="row-span-3">
-                <NavigationMenuLink asChild>
-                  <Link
-                    className="flex h-full w-full select-none flex-col justify-end rounded-md bg-gradient-to-b from-muted/50 to-muted p-6 no-underline outline-none focus:shadow-md"
-                    href="/"
-                  >
-                    <Flame className="h-6 w-6" />
-                    <div className="mb-2 mt-4 text-lg font-medium font-mono ">
-                      SeoCheckup
-                    </div>
-                    <p className="text-sm leading-tight text-muted-foreground">
-                      SEO tools for developers and marketers
-                    </p>
-                  </Link>
-                </NavigationMenuLink>
-              </li>
-              <ListItem
-                href="/sitemap?q=https://freetoolsfr.com/sitemap.xml"
-                title="Sitemap"
-              >
-                Easily review your sitemap by adding your
-                yoursite.com/sitemap.xml.
-              </ListItem>
-              <ListItem
-                href="/metadata?q=https://supwriter.com"
-                title="Meta Data/Tags"
-              >
-                Easily review all website meta tags by adding your link:
-                yoursite.com.
-              </ListItem>
-              <ListItem
-                href="/robots?q=https://freetoolsfr.com/robots.txt"
-                title="Robots.txt"
-              >
-                Inspect robots.txt directives, sitemaps, and crawl rules.
-              </ListItem>
-            </ul>
-          </NavigationMenuContent>
-        </NavigationMenuItem>
-      </NavigationMenuList>
-    </NavigationMenu>
-  )
-}
-
-const ListItem = React.forwardRef<
-  React.ElementRef<"a">,
-  React.ComponentPropsWithoutRef<"a">
->(({ className, title, children, href, ...props }, ref) => {
-  return (
-    <li>
-      <NavigationMenuLink asChild>
-        <Link
-          ref={ref}
-          href={href || "/"}
-          className={cn(
-            "block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
-            className
-          )}
-          {...props}
-        >
-          <div className="text-sm font-medium leading-none font-mono">
-            {title}
-          </div>
-          <p className="text-sm leading-snug text-muted-foreground ">
-            {children}
-          </p>
-        </Link>
-      </NavigationMenuLink>
-    </li>
-  )
-})
-ListItem.displayName = "ListItem"

--- a/components/seo-landing-cta.tsx
+++ b/components/seo-landing-cta.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+
+function normalizeUrl(input: string): string {
+  const trimmed = input.trim()
+  if (!trimmed) return trimmed
+  if (!/^https?:\/\//i.test(trimmed)) {
+    return `https://${trimmed}`
+  }
+  return trimmed
+}
+
+export type SeoLandingCtaProps = {
+  toolPath: string
+  defaultDemoUrl: string
+  inputPlaceholder?: string
+  buttonLabel?: string
+}
+
+export default function SeoLandingCta({
+  toolPath,
+  defaultDemoUrl,
+  inputPlaceholder = "https://example.com",
+  buttonLabel = "Try for free",
+}: SeoLandingCtaProps) {
+  const router = useRouter()
+  const [url, setUrl] = useState(defaultDemoUrl)
+
+  return (
+    <form
+      className="flex flex-col sm:flex-row gap-2 w-full"
+      onSubmit={(e) => {
+        e.preventDefault()
+        const q = normalizeUrl(url) || defaultDemoUrl
+        router.push(`${toolPath}?q=${encodeURIComponent(q)}`)
+      }}
+    >
+      <Input
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        placeholder={inputPlaceholder}
+        className="font-mono"
+        aria-label="URL to check"
+      />
+      <Button type="submit" size="lg" className="shrink-0 w-full sm:w-auto">
+        {buttonLabel}
+      </Button>
+    </form>
+  )
+}

--- a/components/seo-tool-landing.tsx
+++ b/components/seo-tool-landing.tsx
@@ -1,5 +1,7 @@
-import Link from "next/link"
+import JsonLd from "@/components/json-ld"
 import { Button } from "@/components/ui/button"
+import { absoluteUrl } from "@/lib/site"
+import Link from "next/link"
 
 export type SeoLandingFaq = {
   question: string
@@ -21,6 +23,8 @@ type SeoToolLandingProps = {
   related: SeoLandingRelated[]
   canonicalPath: string
   appName: string
+  blogHref: string
+  blogLabel?: string
 }
 
 export default function SeoToolLanding({
@@ -33,8 +37,10 @@ export default function SeoToolLanding({
   related,
   canonicalPath,
   appName,
+  blogHref,
+  blogLabel = "Read the guide",
 }: SeoToolLandingProps) {
-  const pageUrl = `https://seocheckup.vercel.app${canonicalPath}`
+  const pageUrl = absoluteUrl(canonicalPath)
 
   const faqJsonLd = {
     "@context": "https://schema.org",
@@ -83,9 +89,12 @@ export default function SeoToolLanding({
           {pitch}
         </p>
 
-        <div className="mt-8">
+        <div className="mt-8 flex flex-wrap gap-3">
           <Button asChild size="lg">
             <Link href={ctaHref}>{ctaLabel}</Link>
+          </Button>
+          <Button asChild size="lg" variant="outline">
+            <Link href={blogHref}>{blogLabel}</Link>
           </Button>
         </div>
 
@@ -113,11 +122,17 @@ export default function SeoToolLanding({
         </div>
 
         <nav
-          aria-label="Related tools"
+          aria-label="Related links"
           className="mt-14 pt-8 border-t flex flex-wrap gap-x-4 gap-y-2 text-sm"
         >
           <Link href="/" className="underline underline-offset-2">
             Home
+          </Link>
+          <Link
+            href={blogHref}
+            className="underline underline-offset-2 text-muted-foreground hover:text-foreground"
+          >
+            {blogLabel}
           </Link>
           {related.map((item) => (
             <Link
@@ -131,14 +146,8 @@ export default function SeoToolLanding({
         </nav>
       </main>
 
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
-      />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(appJsonLd) }}
-      />
+      <JsonLd data={faqJsonLd} />
+      <JsonLd data={appJsonLd} />
     </section>
   )
 }

--- a/components/seo-tool-landing.tsx
+++ b/components/seo-tool-landing.tsx
@@ -1,0 +1,144 @@
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+
+export type SeoLandingFaq = {
+  question: string
+  answer: string
+}
+
+export type SeoLandingRelated = {
+  href: string
+  label: string
+}
+
+type SeoToolLandingProps = {
+  h1: string
+  pitch: string
+  ctaHref: string
+  ctaLabel?: string
+  benefits: [string, string, string]
+  faqs: [SeoLandingFaq, SeoLandingFaq, SeoLandingFaq]
+  related: SeoLandingRelated[]
+  canonicalPath: string
+  appName: string
+}
+
+export default function SeoToolLanding({
+  h1,
+  pitch,
+  ctaHref,
+  ctaLabel = "Try it free",
+  benefits,
+  faqs,
+  related,
+  canonicalPath,
+  appName,
+}: SeoToolLandingProps) {
+  const pageUrl = `https://seocheckup.vercel.app${canonicalPath}`
+
+  const faqJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqs.map((faq) => ({
+      "@type": "Question",
+      name: faq.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: faq.answer,
+      },
+    })),
+  }
+
+  const appJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    name: appName,
+    url: pageUrl,
+    applicationCategory: "BusinessApplication",
+    operatingSystem: "Any",
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+    },
+    description: pitch,
+  }
+
+  return (
+    <section className="relative flex justify-center flex-col items-center min-h-[83vh]">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10 bg-background
+          bg-[linear-gradient(to_right,hsl(var(--border))_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--border))_1px,transparent_1px)]
+          bg-[size:6rem_4rem]
+          [mask-image:radial-gradient(ellipse_70%_60%_at_50%_30%,black,transparent)]"
+      />
+
+      <main className="w-full max-w-2xl px-4 py-16 md:py-24">
+        <p className="font-mono text-sm text-muted-foreground">SeoCheckup</p>
+        <h1 className="mt-2 text-4xl sm:text-5xl font-bold tracking-tight font-mono">
+          {h1}
+        </h1>
+        <p className="mt-4 text-base sm:text-lg text-muted-foreground">
+          {pitch}
+        </p>
+
+        <div className="mt-8">
+          <Button asChild size="lg">
+            <Link href={ctaHref}>{ctaLabel}</Link>
+          </Button>
+        </div>
+
+        <div className="mt-14">
+          <h2 className="text-lg font-semibold">What you get</h2>
+          <ul className="mt-3 space-y-2 text-sm text-muted-foreground list-disc pl-5">
+            {benefits.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="mt-14">
+          <h2 className="text-lg font-semibold">FAQ</h2>
+          <dl className="mt-4 space-y-5">
+            {faqs.map((faq) => (
+              <div key={faq.question}>
+                <dt className="font-medium">{faq.question}</dt>
+                <dd className="mt-1 text-sm text-muted-foreground">
+                  {faq.answer}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+
+        <nav
+          aria-label="Related tools"
+          className="mt-14 pt-8 border-t flex flex-wrap gap-x-4 gap-y-2 text-sm"
+        >
+          <Link href="/" className="underline underline-offset-2">
+            Home
+          </Link>
+          {related.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="underline underline-offset-2 text-muted-foreground hover:text-foreground"
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+      </main>
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(appJsonLd) }}
+      />
+    </section>
+  )
+}

--- a/components/seo-tool-landing.tsx
+++ b/components/seo-tool-landing.tsx
@@ -1,4 +1,5 @@
 import JsonLd from "@/components/json-ld"
+import SeoLandingCta from "@/components/seo-landing-cta"
 import { Button } from "@/components/ui/button"
 import { absoluteUrl } from "@/lib/site"
 import Link from "next/link"
@@ -16,7 +17,9 @@ export type SeoLandingRelated = {
 type SeoToolLandingProps = {
   h1: string
   pitch: string
-  ctaHref: string
+  toolPath: string
+  defaultDemoUrl: string
+  inputPlaceholder?: string
   ctaLabel?: string
   benefits: [string, string, string]
   faqs: [SeoLandingFaq, SeoLandingFaq, SeoLandingFaq]
@@ -30,8 +33,10 @@ type SeoToolLandingProps = {
 export default function SeoToolLanding({
   h1,
   pitch,
-  ctaHref,
-  ctaLabel = "Try it free",
+  toolPath,
+  defaultDemoUrl,
+  inputPlaceholder,
+  ctaLabel = "Try for free",
   benefits,
   faqs,
   related,
@@ -89,13 +94,18 @@ export default function SeoToolLanding({
           {pitch}
         </p>
 
-        <div className="mt-8 flex flex-wrap gap-3">
-          <Button asChild size="lg">
-            <Link href={ctaHref}>{ctaLabel}</Link>
-          </Button>
-          <Button asChild size="lg" variant="outline">
-            <Link href={blogHref}>{blogLabel}</Link>
-          </Button>
+        <div className="mt-8 space-y-3">
+          <SeoLandingCta
+            toolPath={toolPath}
+            defaultDemoUrl={defaultDemoUrl}
+            inputPlaceholder={inputPlaceholder}
+            buttonLabel={ctaLabel}
+          />
+          <div className="flex flex-wrap gap-3">
+            <Button asChild size="lg" variant="outline">
+              <Link href={blogHref}>{blogLabel}</Link>
+            </Button>
+          </div>
         </div>
 
         <div className="mt-14">

--- a/components/tool-card.tsx
+++ b/components/tool-card.tsx
@@ -1,8 +1,9 @@
 "use client"
+
 import { cn } from "@/lib/utils"
-import React from "react"
-import { Button } from "./ui/button"
+import React, { useState } from "react"
 import Link from "next/link"
+import { useReducedMotion } from "framer-motion"
 
 const ToolCard = ({
   title,
@@ -13,21 +14,31 @@ const ToolCard = ({
   content: string
   link: string
 }) => {
+  const [hovered, setHovered] = useState(false)
+  const reduceMotion = useReducedMotion()
+
   return (
-    <Link href={link}>
+    <Link href={link} className="block h-full">
       <div
-        className="border relative cursor-pointer flex flex-col group justify-between hover:bg-black/50 hover:text-white dark:hover:bg-white/20 hover:backdrop-blur-xl transition-all duration-300
-         overflow-hidden p-6 rounded-xl w-full h-full md:w-[360px] md:h-[200px] bg-background shadow-xl hover:shadow-md"
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        className="border relative cursor-pointer flex flex-col group justify-between
+         hover:bg-black/50 hover:text-white dark:hover:bg-white/20 hover:backdrop-blur-xl
+         transition-all duration-[var(--duration-normal)] ease-[var(--ease-out)]
+         overflow-hidden p-6 rounded-xl w-full h-full min-h-[180px] bg-background shadow-xl hover:shadow-md"
       >
+        {hovered && !reduceMotion && <Meteors number={12} />}
         <div className="z-10 relative">
           <h3 className="text-2xl font-semibold">{title}</h3>
-          <p className="text-sm mt-2 font-mono">{content}</p>
+          <p className="text-sm mt-2 font-mono text-muted-foreground group-hover:text-inherit">
+            {content}
+          </p>
         </div>
 
-        <button className="mt-4 md:mt-0 group relative w-fit m-1 inline-flex cursor-pointer items-center justify-center overflow-hidden rounded-lg border-b-2 border-l-2 border-r-2 border-black/70 dark:border-white/70 bg-gradient-to-tr from-black/80 to-black/50 dark:from-white/80 dark:to-white/50 px-4 py-1 text-white dark:text-black shadow-lg transition duration-100 ease-in-out active:translate-y-0.5 active:border-black/50 active:shadow-none">
-          <span className="absolute h-0 w-0 rounded-full bg-white opacity-10 transition-all duration-300 ease-out group-hover:h-32 group-hover:w-32"></span>
+        <span className="mt-4 z-10 relative w-fit inline-flex cursor-pointer items-center justify-center overflow-hidden rounded-lg border-b-2 border-l-2 border-r-2 border-black/70 dark:border-white/70 bg-gradient-to-tr from-black/80 to-black/50 dark:from-white/80 dark:to-white/50 px-4 py-1 text-white dark:text-black shadow-lg transition duration-[var(--duration-fast)] ease-[var(--ease-out)] active:translate-y-0.5">
+          <span className="absolute h-0 w-0 rounded-full bg-white opacity-10 transition-all duration-[var(--duration-normal)] ease-[var(--ease-out)] group-hover:h-32 group-hover:w-32" />
           <span className="relative font-medium">Try Now</span>
-        </button>
+        </span>
       </div>
     </Link>
   )
@@ -35,35 +46,39 @@ const ToolCard = ({
 
 export default ToolCard
 
+function meteorStyle(idx: number) {
+  const left = ((idx * 73) % 800) - 400
+  const delay = 0.2 + ((idx * 37) % 60) / 100
+  const duration = 2 + ((idx * 17) % 8)
+  return {
+    top: 0,
+    left: `${left}px`,
+    animationDelay: `${delay}s`,
+    animationDuration: `${duration}s`,
+  }
+}
+
 export const Meteors = ({
-  number,
+  number = 20,
   className,
-  hover,
 }: {
   number?: number
   className?: string
-  hover?: boolean
 }) => {
-  const meteors = new Array(number || 20).fill(true)
+  const meteors = Array.from({ length: number }, (_, idx) => idx)
+
   return (
     <>
-      {meteors.map((el, idx) => (
+      {meteors.map((idx) => (
         <span
           key={"meteor" + idx}
           className={cn(
-            "animate-meteor-effect absolute top-1/2 left-1/2 h-0.5 w-0.5 rounded-[9999px] bg-slate-500 shadow-[0_0_0_1px_#ffffff10] rotate-[215deg]",
-            "before:content-[''] before:absolute before:top-1/2 before:transform before:-translate-y-[50%] before:w-[50px] before:h-[1px] before:bg-gradient-to-r before:from-[#64748b] before:to-transparent",
+            "animate-meteor-effect absolute top-1/2 left-1/2 h-0.5 w-0.5 rounded-[9999px] bg-muted-foreground/50 shadow-[0_0_0_1px_#ffffff10] rotate-[215deg]",
+            "before:content-[''] before:absolute before:top-1/2 before:transform before:-translate-y-[50%] before:w-[50px] before:h-[1px] before:bg-gradient-to-r before:from-muted-foreground before:to-transparent",
             className
           )}
-          style={{
-            top: 0,
-            left: Math.floor(Math.random() * (400 - -400) + -400) + "px",
-            animationDelay: Math.random() * (0.8 - 0.2) + 0.2 + "s",
-            animationDuration: hover
-              ? Math.floor(Math.random() * (10 - 2) + 2) + "s"
-              : "2s",
-          }}
-        ></span>
+          style={meteorStyle(idx)}
+        />
       ))}
     </>
   )

--- a/components/tool-related-links.tsx
+++ b/components/tool-related-links.tsx
@@ -1,0 +1,35 @@
+import type { FeatureKey } from "@/lib/site"
+import { blogPath, features } from "@/lib/site"
+import Link from "next/link"
+
+type ToolRelatedLinksProps = {
+  feature: FeatureKey
+}
+
+/** Light “Learn more / Guide” strip for interactive tool pages */
+export default function ToolRelatedLinks({ feature }: ToolRelatedLinksProps) {
+  const f = features[feature]
+
+  return (
+    <nav
+      aria-label="Related resources"
+      className="mt-12 pt-6 border-t w-full max-w-lg px-4 text-sm text-muted-foreground flex flex-wrap gap-x-4 gap-y-2 justify-center"
+    >
+      <Link
+        href={f.landingPath}
+        className="underline underline-offset-2 hover:text-foreground"
+      >
+        Learn more
+      </Link>
+      <Link
+        href={blogPath(f.blogSlug)}
+        className="underline underline-offset-2 hover:text-foreground"
+      >
+        Guide
+      </Link>
+      <Link href="/" className="underline underline-offset-2 hover:text-foreground">
+        Home
+      </Link>
+    </nav>
+  )
+}

--- a/content/blog/free-website-seo-audit.mdx
+++ b/content/blog/free-website-seo-audit.mdx
@@ -1,0 +1,41 @@
+# How to Run a Free Website SEO Audit
+
+A useful SEO audit does not need fifty locked cards or a sales funnel. It needs clear signals you can act on: can crawlers reach the site, can they find your URLs, and does the homepage send healthy on-page and trust signals?
+
+## What SeoCheckup checks
+
+Our [free site audit](/audit) pulls a single origin and reviews three groups:
+
+1. **On-page** — title, meta description, H1, canonical, `lang`, charset, viewport, favicon, robots meta, Open Graph, Twitter tags, and JSON-LD presence.
+2. **Robots & sitemap** — whether `robots.txt` loads, whether it declares `Sitemap:` lines, and whether an XML sitemap (or index) expands to real page URLs.
+3. **Trust & authority** — HTTPS, common security headers, and [Ahrefs Domain Rating](/domain-rating) from the free public endpoint.
+
+We intentionally skip PageSpeed / Lighthouse in this free audit. Those need separate performance APIs and often muddy a crawlability report.
+
+## How to run it
+
+1. Open the [Site Audit tool](/audit).
+2. Paste your homepage URL (or try `https://shrix1.com`).
+3. Read **Fix first** — fails and warnings sorted by severity.
+4. Expand categories for full values (nothing is paywalled).
+5. Use **Copy report** if you want to paste findings into an LLM or ticket.
+
+## How to prioritize fixes
+
+- **Fails first** — missing title, noindex on a public homepage, unreachable robots.txt, or a broken sitemap block discovery.
+- **Warnings next** — short descriptions, missing HSTS, absent JSON-LD. Useful, but rarely as urgent as crawl blockers.
+- **Deep-link tools** — jump into [Sitemap](/sitemap), [Metadata](/metadata), [Robots](/robots), or [Domain Rating](/domain-rating) for a closer look.
+
+## FAQ
+
+### Is a free audit enough for enterprise SEO?
+
+It is a strong first pass for technical hygiene. Large sites still need crawl logs, Search Console, and content quality reviews.
+
+### Will the audit crawl every page?
+
+No. It audits the homepage HTML plus robots/sitemap discovery. That is enough to catch most “site is uncrawlable” mistakes without a multi-hour crawl.
+
+### Is Domain Rating required for a good score?
+
+No. DR is one trust signal. A brand-new site can still pass on-page and crawl checks with a low DR.

--- a/content/blog/how-to-check-meta-tags.mdx
+++ b/content/blog/how-to-check-meta-tags.mdx
@@ -1,0 +1,39 @@
+# How to Check Meta Tags and Social Previews
+
+Title tags and meta descriptions shape how your page appears in search results. Open Graph tags shape how it looks when shared on social platforms. Checking them before launch prevents empty or truncated previews.
+
+## What matters most
+
+- **Title** — unique, descriptive, roughly 30–60 characters
+- **Meta description** — supporting snippet, roughly 70–160 characters
+- **Open Graph** — `og:title`, `og:description`, `og:image` for share cards
+- **Optional Twitter tags** — useful when you want X-specific cards
+
+## Check it free
+
+Use the [Meta Tags Checker](/metadata) or start from the [Meta Tags Checker landing page](/meta-tags-checker). Paste a page URL and preview title, description, and social image fields.
+
+## Tips that actually help
+
+- Match the title to the primary intent of the page — not a keyword dump
+- Avoid duplicate titles across important URLs
+- Prefer absolute HTTPS URLs for `og:image`
+- Re-check after framework or CMS theme changes; tags often disappear quietly
+
+## Combine with an audit
+
+If you want robots, sitemap, headers, and meta in one pass, run the [free Site Audit](/audit).
+
+## FAQ
+
+### Does Google always show my meta description?
+
+No. Google may rewrite snippets from page content. A clear description still helps when it is used.
+
+### Are Open Graph tags a ranking factor?
+
+They mainly affect social presentation. They still matter for brand clicks and sharing quality.
+
+### Is this tool free?
+
+Yes. SeoCheckup’s metadata viewer is free to use.

--- a/content/blog/how-to-check-robots-txt.mdx
+++ b/content/blog/how-to-check-robots-txt.mdx
@@ -1,0 +1,36 @@
+# How to Check robots.txt (Without Breaking Crawl Access)
+
+`robots.txt` lives at the site root — `https://example.com/robots.txt`. Crawlers read it before fetching other paths. A single mistaken `Disallow: /` can hide an entire site from polite bots.
+
+## What to look for
+
+- File is reachable (HTTP 200) at the root
+- `User-agent` blocks are intentional
+- Critical assets (CSS/JS) are not blocked if you need rendering
+- `Sitemap:` lines point to real XML sitemaps
+- You understand that **Disallow ≠ noindex** — blocking fetch is not the same as removing a URL from results
+
+## Check it free
+
+Open the [Robots.txt Viewer](/robots) or the [Robots.txt Checker landing](/robots-txt-checker). Paste the robots URL and scan highlighted directives.
+
+## Safe workflow
+
+1. Review production `robots.txt` after deploys
+2. Confirm staging sites stay disallowed if that is intended
+3. Cross-check declared sitemaps with the [Sitemap Checker](/sitemap)
+4. Run a [Site Audit](/audit) if you want homepage + robots + sitemap together
+
+## FAQ
+
+### Where must robots.txt live?
+
+Only at the origin root. `/blog/robots.txt` is ignored for the whole site.
+
+### Does Disallow stop indexing?
+
+Not reliably. Crawlers may still index a URL from external links without fetching it. Use `noindex` when you need to keep a page out of results.
+
+### Is the checker free?
+
+Yes — SeoCheckup’s robots viewer is free.

--- a/content/blog/how-to-check-xml-sitemap.mdx
+++ b/content/blog/how-to-check-xml-sitemap.mdx
@@ -1,0 +1,41 @@
+# How to Check an XML Sitemap (Including Indexes)
+
+An XML sitemap lists the URLs you want search engines to discover. Large sites often use a **sitemap index** that points to child sitemaps instead of listing every page in one file.
+
+## What to verify
+
+- The sitemap URL returns valid XML (`urlset` or `sitemapindex`)
+- Child sitemaps in an index are reachable on the same host
+- Page URLs expand without silent truncation for your use case
+- `robots.txt` declares a `Sitemap:` line pointing at the right file
+
+## Check it free
+
+Open the [XML Sitemap Checker](/sitemap) (or the [marketing page](/sitemap-checker)) and paste your sitemap URL — for example `https://yoursite.com/sitemap.xml`.
+
+SeoCheckup expands indexes recursively (with sensible depth and size caps), shows a URL count, and lets you filter by child sitemap when you are looking at an index.
+
+## Common mistakes
+
+- Publishing only a homepage URL in the sitemap while thousands of pages exist elsewhere
+- Listing staging or `noindex` URLs you never meant to submit
+- Pointing `Sitemap:` in robots.txt at a 404
+- Mixing hosts across child sitemaps (we skip cross-host children for safety)
+
+## Next steps
+
+After the sitemap looks healthy, confirm the homepage tags with the [Meta Tags Checker](/metadata) or run a combined [Site Audit](/audit).
+
+## FAQ
+
+### Does Google require a sitemap?
+
+No, but sitemaps help discovery on large or poorly linked sites.
+
+### What is a sitemap index?
+
+An XML file whose root is `sitemapindex` and whose entries are other sitemap URLs, not page URLs.
+
+### Is the checker free?
+
+Yes — no account required for the SeoCheckup sitemap tool.

--- a/content/blog/what-is-domain-rating.mdx
+++ b/content/blog/what-is-domain-rating.mdx
@@ -1,0 +1,39 @@
+# What Is Domain Rating? (And How to Check It Free)
+
+**Domain Rating (DR)** is Ahrefs’ metric for the relative strength of a website’s backlink profile. It uses a 100-point logarithmic scale: moving from DR 10 to 20 is very different from moving from DR 70 to 80.
+
+## Why people check DR
+
+- Quick sense of competitive authority when comparing domains
+- Rough qualification for link outreach or partnership lists
+- Context alongside on-page and crawlability checks
+
+DR is **not** a Google ranking factor published by Google. It is a third-party estimate of backlink strength.
+
+## Check DR free on SeoCheckup
+
+Use the [Domain Rating Checker](/domain-rating). Paste a domain or full URL. We call Ahrefs’ public free endpoint (`domain-rating-free`) — no API key and no paid Ahrefs plan required.
+
+Whenever DR is shown, we include the required attribution: [Domain Rating by Ahrefs](https://ahrefs.com/).
+
+## What a “good” DR looks like
+
+There is no universal good score. A local business can rank well with a low DR. A competitive SaaS niche may need a much higher profile. Use DR comparatively, not as a vanity target.
+
+## Pair DR with a full audit
+
+Authority without crawl access still fails. After you check DR, run a [free site audit](/audit) for robots, sitemap, meta tags, and security headers.
+
+## FAQ
+
+### Is this the same as Domain Authority?
+
+No. Domain Authority is Moz’s metric. Domain Rating is Ahrefs’. They correlate loosely but are not interchangeable.
+
+### Can I get historical DR charts here?
+
+Not in the free checker. We return the current public DR value only.
+
+### Do I need to attribute Ahrefs?
+
+Yes. Ahrefs’ Domain Rating license requires visible attribution when you display DR. SeoCheckup always includes it.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig, globalIgnores } from "eslint/config"
+import nextVitals from "eslint-config-next/core-web-vitals"
+
+export default defineConfig([
+  ...nextVitals,
+  globalIgnores([".next/**", "out/**", "node_modules/**", "plans/**"]),
+])

--- a/lib/ahrefs-dr.ts
+++ b/lib/ahrefs-dr.ts
@@ -1,0 +1,65 @@
+export const AHREFS_DR_ATTRIBUTION = {
+  text: "Domain Rating by Ahrefs",
+  href: "https://ahrefs.com/",
+  license: "https://ahrefs.com/legal/domain-rating-license",
+} as const
+
+export type DomainRatingResult = {
+  domain: string
+  domainRating: number | null
+  error?: string
+}
+
+export async function fetchDomainRating(
+  target: string
+): Promise<DomainRatingResult> {
+  const domain = target
+    .replace(/^https?:\/\//i, "")
+    .replace(/\/.*$/, "")
+    .replace(/^www\./i, "")
+    .trim()
+
+  if (!domain) {
+    return { domain: "", domainRating: null, error: "Invalid domain" }
+  }
+
+  try {
+    const url = new URL("https://api.ahrefs.com/v3/public/domain-rating-free")
+    url.searchParams.set("target", domain)
+
+    const res = await fetch(url.toString(), {
+      signal: AbortSignal.timeout(15_000),
+      headers: { Accept: "application/json" },
+    })
+
+    if (!res.ok) {
+      return {
+        domain,
+        domainRating: null,
+        error: `Ahrefs returned ${res.status}`,
+      }
+    }
+
+    const data = (await res.json()) as {
+      domain_rating?: { domain_rating?: number }
+      error?: string
+    }
+
+    const rating = data.domain_rating?.domain_rating
+    if (typeof rating !== "number") {
+      return {
+        domain,
+        domainRating: null,
+        error: data.error || "No domain rating returned",
+      }
+    }
+
+    return { domain, domainRating: rating }
+  } catch (err) {
+    return {
+      domain,
+      domainRating: null,
+      error: err instanceof Error ? err.message : "Domain rating fetch failed",
+    }
+  }
+}

--- a/lib/audit/parse-html.ts
+++ b/lib/audit/parse-html.ts
@@ -1,0 +1,162 @@
+function decodeEntities(value: string): string {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+}
+
+function attr(
+  tag: string,
+  name: string
+): string | undefined {
+  const re = new RegExp(
+    `${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`,
+    "i"
+  )
+  const m = tag.match(re)
+  return m?.[1] ?? m?.[2] ?? m?.[3]
+}
+
+function metaByNameOrProperty(html: string, key: string): string | undefined {
+  const tags = html.match(/<meta\b[^>]*>/gi) || []
+  for (const tag of tags) {
+    const name = attr(tag, "name") || attr(tag, "property")
+    if (name?.toLowerCase() === key.toLowerCase()) {
+      const content = attr(tag, "content")
+      if (content !== undefined) return decodeEntities(content.trim())
+    }
+  }
+  return undefined
+}
+
+export type ParsedHtml = {
+  title?: string
+  description?: string
+  canonical?: string
+  lang?: string
+  charset?: string
+  viewport?: string
+  favicon?: string
+  robotsMeta?: string
+  h1Count: number
+  ogTitle?: string
+  ogDescription?: string
+  ogImage?: string
+  ogType?: string
+  ogUrl?: string
+  twitterCard?: string
+  twitterTitle?: string
+  twitterDescription?: string
+  twitterImage?: string
+  jsonLdTypes: string[]
+  hasJsonLd: boolean
+}
+
+export function parseHtml(html: string): ParsedHtml {
+  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)
+  const title = titleMatch?.[1]
+    ? decodeEntities(titleMatch[1].replace(/\s+/g, " ").trim())
+    : undefined
+
+  const htmlLang = html.match(/<html\b[^>]*\blang\s*=\s*(?:"([^"]*)"|'([^']*)')/i)
+  const lang = htmlLang?.[1] || htmlLang?.[2]
+
+  let charset: string | undefined
+  const charsetMeta = html.match(
+    /<meta\b[^>]*charset\s*=\s*(?:"([^"]*)"|'([^']*)'|([^>\s]+))/i
+  )
+  if (charsetMeta) {
+    charset = (charsetMeta[1] || charsetMeta[2] || charsetMeta[3])?.trim()
+  }
+  if (!charset) {
+    const httpEquiv = metaByNameOrProperty(html, "content-type")
+    const m = httpEquiv?.match(/charset=([^\s;]+)/i)
+    if (m) charset = m[1]
+  }
+
+  const linkTags = html.match(/<link\b[^>]*>/gi) || []
+  let canonical: string | undefined
+  let favicon: string | undefined
+  for (const tag of linkTags) {
+    const rel = (attr(tag, "rel") || "").toLowerCase()
+    const href = attr(tag, "href")
+    if (!href) continue
+    if (rel.split(/\s+/).includes("canonical")) {
+      canonical = decodeEntities(href.trim())
+    }
+    if (
+      !favicon &&
+      (rel.includes("icon") || rel === "shortcut icon" || rel === "apple-touch-icon")
+    ) {
+      favicon = decodeEntities(href.trim())
+    }
+  }
+
+  const h1Count = (html.match(/<h1\b[^>]*>/gi) || []).length
+
+  const jsonLdTypes: string[] = []
+  const scripts = html.matchAll(
+    /<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi
+  )
+  for (const match of scripts) {
+    const raw = match[1]?.trim()
+    if (!raw) continue
+    try {
+      const data = JSON.parse(raw) as unknown
+      const collect = (node: unknown) => {
+        if (!node || typeof node !== "object") return
+        if (Array.isArray(node)) {
+          node.forEach(collect)
+          return
+        }
+        const obj = node as Record<string, unknown>
+        const t = obj["@type"]
+        if (typeof t === "string") jsonLdTypes.push(t)
+        else if (Array.isArray(t)) {
+          for (const item of t) {
+            if (typeof item === "string") jsonLdTypes.push(item)
+          }
+        }
+        if (obj["@graph"]) collect(obj["@graph"])
+      }
+      collect(data)
+    } catch {
+      // ignore invalid JSON-LD
+    }
+  }
+
+  return {
+    title,
+    description: metaByNameOrProperty(html, "description"),
+    canonical,
+    lang,
+    charset,
+    viewport: metaByNameOrProperty(html, "viewport"),
+    favicon,
+    robotsMeta: metaByNameOrProperty(html, "robots"),
+    h1Count,
+    ogTitle: metaByNameOrProperty(html, "og:title"),
+    ogDescription: metaByNameOrProperty(html, "og:description"),
+    ogImage: metaByNameOrProperty(html, "og:image"),
+    ogType: metaByNameOrProperty(html, "og:type"),
+    ogUrl: metaByNameOrProperty(html, "og:url"),
+    twitterCard: metaByNameOrProperty(html, "twitter:card"),
+    twitterTitle: metaByNameOrProperty(html, "twitter:title"),
+    twitterDescription: metaByNameOrProperty(html, "twitter:description"),
+    twitterImage: metaByNameOrProperty(html, "twitter:image"),
+    jsonLdTypes: [...new Set(jsonLdTypes)],
+    hasJsonLd: jsonLdTypes.length > 0 || /application\/ld\+json/i.test(html),
+  }
+}
+
+export function parseSitemapLines(robotsBody: string): string[] {
+  const urls: string[] = []
+  for (const line of robotsBody.split(/\r?\n/)) {
+    const m = line.match(/^\s*Sitemap\s*:\s*(\S+)/i)
+    if (m?.[1]) urls.push(m[1].trim())
+  }
+  return [...new Set(urls)]
+}

--- a/lib/audit/run-audit.ts
+++ b/lib/audit/run-audit.ts
@@ -1,0 +1,477 @@
+import { fetchDomainRating } from "@/lib/ahrefs-dr"
+import { fetchUrl, hostnameFromInput, normalizeOrigin } from "@/lib/fetch-url"
+import { expandSitemap } from "@/lib/sitemap-expand"
+import { parseHtml, parseSitemapLines } from "@/lib/audit/parse-html"
+import type {
+  AuditCheck,
+  AuditReport,
+  CategoryScore,
+  CheckStatus,
+} from "@/lib/audit/types"
+
+const CATEGORY_LABELS = {
+  onpage: "On-page",
+  crawl: "Robots & sitemap",
+  trust: "Trust & authority",
+} as const
+
+function scoreFromChecks(checks: AuditCheck[]): {
+  score: number
+  pass: number
+  warn: number
+  fail: number
+} {
+  let pass = 0
+  let warn = 0
+  let fail = 0
+  let points = 0
+  let max = 0
+  for (const c of checks) {
+    max += 2
+    if (c.status === "pass") {
+      pass += 1
+      points += 2
+    } else if (c.status === "warn") {
+      warn += 1
+      points += 1
+    } else {
+      fail += 1
+    }
+  }
+  return {
+    score: max === 0 ? 0 : Math.round((points / max) * 100),
+    pass,
+    warn,
+    fail,
+  }
+}
+
+function statusOrder(status: CheckStatus): number {
+  return status === "fail" ? 0 : status === "warn" ? 1 : 2
+}
+
+export async function runAudit(input: string): Promise<AuditReport> {
+  const originUrl = normalizeOrigin(input)
+  const origin = originUrl.origin
+  const domain = hostnameFromInput(input)
+  const homeUrl = `${origin}/`
+  const robotsUrl = `${origin}/robots.txt`
+  const metadataDeep = `/metadata?q=${encodeURIComponent(origin)}`
+  const robotsDeep = `/robots?q=${encodeURIComponent(robotsUrl)}`
+  const drDeep = `/domain-rating?q=${encodeURIComponent(domain)}`
+
+  const [homeRes, robotsRes, drRes] = await Promise.all([
+    fetchUrl(homeUrl),
+    fetchUrl(robotsUrl),
+    fetchDomainRating(domain),
+  ])
+
+  const parsed = homeRes.ok ? parseHtml(homeRes.body) : parseHtml("")
+  const checks: AuditCheck[] = []
+
+  // --- On-page ---
+  const titleLen = parsed.title?.length ?? 0
+  checks.push({
+    id: "title",
+    category: "onpage",
+    label: "Title tag",
+    status: !parsed.title
+      ? "fail"
+      : titleLen < 15 || titleLen > 65
+        ? "warn"
+        : "pass",
+    value: parsed.title || "(missing)",
+    detail: parsed.title
+      ? `${titleLen} characters`
+      : "No <title> found on the homepage",
+    fixHint: "Add a unique title of roughly 30–60 characters.",
+    deepLink: metadataDeep,
+  })
+
+  const descLen = parsed.description?.length ?? 0
+  checks.push({
+    id: "description",
+    category: "onpage",
+    label: "Meta description",
+    status: !parsed.description
+      ? "fail"
+      : descLen < 50 || descLen > 165
+        ? "warn"
+        : "pass",
+    value: parsed.description || "(missing)",
+    detail: parsed.description
+      ? `${descLen} characters`
+      : "No meta description found",
+    fixHint: "Add a meta description around 70–160 characters.",
+    deepLink: metadataDeep,
+  })
+
+  checks.push({
+    id: "h1",
+    category: "onpage",
+    label: "H1 heading",
+    status:
+      parsed.h1Count === 1 ? "pass" : parsed.h1Count === 0 ? "fail" : "warn",
+    value: String(parsed.h1Count),
+    detail:
+      parsed.h1Count === 1
+        ? "Exactly one H1 found"
+        : parsed.h1Count === 0
+          ? "No H1 found"
+          : `${parsed.h1Count} H1 tags found`,
+    fixHint: "Use a single clear H1 that describes the page.",
+  })
+
+  checks.push({
+    id: "canonical",
+    category: "onpage",
+    label: "Canonical URL",
+    status: parsed.canonical ? "pass" : "warn",
+    value: parsed.canonical || "(missing)",
+    detail: parsed.canonical
+      ? "Canonical link present"
+      : "No rel=canonical link",
+    fixHint: "Add a self-referencing canonical to avoid duplicate URLs.",
+  })
+
+  checks.push({
+    id: "lang",
+    category: "onpage",
+    label: "HTML lang",
+    status: parsed.lang ? "pass" : "warn",
+    value: parsed.lang || "(missing)",
+    detail: parsed.lang
+      ? `lang="${parsed.lang}"`
+      : "Missing lang attribute on <html>",
+    fixHint: 'Set html lang, e.g. lang="en".',
+  })
+
+  checks.push({
+    id: "charset",
+    category: "onpage",
+    label: "Character encoding",
+    status: parsed.charset ? "pass" : "warn",
+    value: parsed.charset || "(missing)",
+    detail: parsed.charset
+      ? `Charset ${parsed.charset}`
+      : "No charset meta declared",
+    fixHint: "Declare <meta charset=\"utf-8\"> early in <head>.",
+  })
+
+  checks.push({
+    id: "viewport",
+    category: "onpage",
+    label: "Viewport meta",
+    status: parsed.viewport
+      ? /width\s*=\s*device-width/i.test(parsed.viewport)
+        ? "pass"
+        : "warn"
+      : "fail",
+    value: parsed.viewport || "(missing)",
+    detail: parsed.viewport
+      ? "Viewport meta present"
+      : "Missing viewport meta for mobile",
+    fixHint: 'Add <meta name="viewport" content="width=device-width, initial-scale=1">.',
+  })
+
+  checks.push({
+    id: "favicon",
+    category: "onpage",
+    label: "Favicon",
+    status: parsed.favicon ? "pass" : "warn",
+    value: parsed.favicon || "(missing)",
+    detail: parsed.favicon ? "Favicon link found" : "No favicon link found",
+    fixHint: "Add a <link rel=\"icon\"> in the document head.",
+  })
+
+  const robotsMeta = (parsed.robotsMeta || "").toLowerCase()
+  const noindex = robotsMeta.includes("noindex")
+  checks.push({
+    id: "indexable",
+    category: "onpage",
+    label: "Indexability (robots meta)",
+    status: noindex ? "fail" : "pass",
+    value: parsed.robotsMeta || "index (default)",
+    detail: noindex
+      ? "Homepage meta robots includes noindex"
+      : "Homepage is not blocked by robots meta",
+    fixHint: "Remove noindex from public pages you want indexed.",
+  })
+
+  checks.push({
+    id: "jsonld",
+    category: "onpage",
+    label: "Structured data (JSON-LD)",
+    status: parsed.hasJsonLd ? "pass" : "warn",
+    value: parsed.jsonLdTypes.length
+      ? parsed.jsonLdTypes.join(", ")
+      : parsed.hasJsonLd
+        ? "Present"
+        : "(none)",
+    detail: parsed.hasJsonLd
+      ? "JSON-LD structured data detected"
+      : "No JSON-LD found",
+    fixHint: "Add relevant Schema.org JSON-LD for the page type.",
+  })
+
+  checks.push({
+    id: "og",
+    category: "onpage",
+    label: "Open Graph basics",
+    status:
+      parsed.ogTitle && parsed.ogDescription && parsed.ogImage
+        ? "pass"
+        : parsed.ogTitle || parsed.ogImage
+          ? "warn"
+          : "fail",
+    value: [
+      parsed.ogTitle ? "title" : null,
+      parsed.ogDescription ? "description" : null,
+      parsed.ogImage ? "image" : null,
+    ]
+      .filter(Boolean)
+      .join(", ") || "(missing)",
+    detail: "OG title, description, and image for social previews",
+    fixHint: "Set og:title, og:description, and og:image.",
+    deepLink: metadataDeep,
+  })
+
+  checks.push({
+    id: "twitter",
+    category: "onpage",
+    label: "Twitter Card tags",
+    status:
+      parsed.twitterCard || parsed.twitterTitle || parsed.twitterImage
+        ? "pass"
+        : "warn",
+    value: parsed.twitterCard || parsed.twitterTitle || "(missing)",
+    detail:
+      parsed.twitterCard || parsed.twitterTitle
+        ? "Twitter Card tags present"
+        : "No Twitter Card tags (OG may still work)",
+    fixHint: "Optional: add twitter:card and twitter:image.",
+    deepLink: metadataDeep,
+  })
+
+  if (!homeRes.ok) {
+    checks.push({
+      id: "homepage",
+      category: "onpage",
+      label: "Homepage fetch",
+      status: "fail",
+      value: homeRes.error || `HTTP ${homeRes.status}`,
+      detail: "Could not fetch the homepage HTML",
+      fixHint: "Confirm the site is publicly reachable over HTTPS.",
+    })
+  }
+
+  // --- Crawl: robots + sitemap ---
+  checks.push({
+    id: "robots",
+    category: "crawl",
+    label: "robots.txt reachable",
+    status: robotsRes.ok ? "pass" : "fail",
+    value: robotsRes.ok
+      ? `${robotsRes.status}`
+      : robotsRes.error || `HTTP ${robotsRes.status}`,
+    detail: robotsRes.ok
+      ? "robots.txt returned successfully"
+      : "Could not fetch robots.txt",
+    fixHint: "Publish a robots.txt at the site root.",
+    deepLink: robotsDeep,
+  })
+
+  const sitemapFromRobots = robotsRes.ok
+    ? parseSitemapLines(robotsRes.body)
+    : []
+  checks.push({
+    id: "robots-sitemap",
+    category: "crawl",
+    label: "Sitemap declared in robots.txt",
+    status: sitemapFromRobots.length > 0 ? "pass" : "warn",
+    value:
+      sitemapFromRobots.length > 0
+        ? sitemapFromRobots.join(", ")
+        : "(none)",
+    detail:
+      sitemapFromRobots.length > 0
+        ? `${sitemapFromRobots.length} Sitemap directive(s)`
+        : "No Sitemap: lines in robots.txt",
+    fixHint: "Add Sitemap: https://yoursite.com/sitemap.xml to robots.txt.",
+    deepLink: robotsDeep,
+  })
+
+  const sitemapCandidates = [
+    ...sitemapFromRobots,
+    `${origin}/sitemap.xml`,
+  ]
+  const uniqueSitemaps = [...new Set(sitemapCandidates)]
+
+  let sitemapUrlUsed = uniqueSitemaps[0]
+  let sitemapUrlCount = 0
+  let sitemapTruncated = false
+  let sitemapError: string | undefined
+  let sitemapExpanded = false
+
+  for (const candidate of uniqueSitemaps) {
+    try {
+      const expanded = await expandSitemap(candidate)
+      if (expanded.urls.length > 0 || expanded.rootKind !== "unknown") {
+        sitemapUrlUsed = candidate
+        sitemapUrlCount = expanded.urls.length
+        sitemapTruncated = expanded.truncated
+        sitemapExpanded = true
+        if (expanded.urls.length === 0 && expanded.childSitemapsFailed.length) {
+          sitemapError = expanded.childSitemapsFailed[0]?.reason
+        }
+        break
+      }
+    } catch (err) {
+      sitemapError = err instanceof Error ? err.message : "Expand failed"
+    }
+  }
+
+  const sitemapDeep = `/sitemap?q=${encodeURIComponent(sitemapUrlUsed)}`
+  checks.push({
+    id: "sitemap",
+    category: "crawl",
+    label: "XML sitemap expands",
+    status: !sitemapExpanded
+      ? "fail"
+      : sitemapUrlCount === 0
+        ? "warn"
+        : "pass",
+    value: sitemapExpanded
+      ? `${sitemapUrlCount} URLs${sitemapTruncated ? " (truncated)" : ""}`
+      : sitemapError || "Not found",
+    detail: sitemapExpanded
+      ? `Expanded ${sitemapUrlUsed}`
+      : "Could not expand a sitemap for this origin",
+    fixHint: "Publish a valid XML sitemap and reference it in robots.txt.",
+    deepLink: sitemapDeep,
+  })
+
+  // --- Trust ---
+  const finalIsHttps = homeRes.finalUrl.startsWith("https:")
+  checks.push({
+    id: "https",
+    category: "trust",
+    label: "HTTPS",
+    status: finalIsHttps ? "pass" : "fail",
+    value: homeRes.finalUrl || origin,
+    detail: finalIsHttps
+      ? "Final URL uses HTTPS"
+      : "Site did not resolve to HTTPS",
+    fixHint: "Serve the site over HTTPS and redirect HTTP to HTTPS.",
+  })
+
+  const hsts = homeRes.headers.get("strict-transport-security")
+  checks.push({
+    id: "hsts",
+    category: "trust",
+    label: "HSTS header",
+    status: hsts ? "pass" : "warn",
+    value: hsts || "(missing)",
+    detail: hsts
+      ? "Strict-Transport-Security present"
+      : "No HSTS response header",
+    fixHint: "Enable HSTS on your HTTPS responses.",
+  })
+
+  const csp = homeRes.headers.get("content-security-policy")
+  checks.push({
+    id: "csp",
+    category: "trust",
+    label: "Content-Security-Policy",
+    status: csp ? "pass" : "warn",
+    value: csp ? "Present" : "(missing)",
+    detail: csp ? "CSP header present" : "No CSP header",
+    fixHint: "Add a Content-Security-Policy suited to your app.",
+  })
+
+  const xfo = homeRes.headers.get("x-frame-options")
+  checks.push({
+    id: "xfo",
+    category: "trust",
+    label: "Frame protection",
+    status: xfo || csp?.toLowerCase().includes("frame-ancestors") ? "pass" : "warn",
+    value: xfo || (csp?.includes("frame-ancestors") ? "CSP frame-ancestors" : "(missing)"),
+    detail: "X-Frame-Options or CSP frame-ancestors",
+    fixHint: "Set X-Frame-Options or CSP frame-ancestors.",
+  })
+
+  const xcto = homeRes.headers.get("x-content-type-options")
+  checks.push({
+    id: "xcto",
+    category: "trust",
+    label: "MIME sniffing protection",
+    status: xcto?.toLowerCase() === "nosniff" ? "pass" : "warn",
+    value: xcto || "(missing)",
+    detail:
+      xcto?.toLowerCase() === "nosniff"
+        ? "X-Content-Type-Options: nosniff"
+        : "Missing X-Content-Type-Options: nosniff",
+    fixHint: "Send X-Content-Type-Options: nosniff.",
+  })
+
+  checks.push({
+    id: "domain-rating",
+    category: "trust",
+    label: "Domain Rating",
+    status:
+      typeof drRes.domainRating === "number"
+        ? drRes.domainRating >= 10
+          ? "pass"
+          : "warn"
+        : "warn",
+    value:
+      typeof drRes.domainRating === "number"
+        ? String(Math.round(drRes.domainRating))
+        : drRes.error || "Unavailable",
+    detail:
+      typeof drRes.domainRating === "number"
+        ? `Ahrefs Domain Rating ${Math.round(drRes.domainRating)}/100`
+        : "Could not load Domain Rating",
+    fixHint: "Build quality backlinks over time to grow Domain Rating.",
+    deepLink: drDeep,
+  })
+
+  const byCat = {
+    onpage: checks.filter((c) => c.category === "onpage"),
+    crawl: checks.filter((c) => c.category === "crawl"),
+    trust: checks.filter((c) => c.category === "trust"),
+  }
+
+  const categories: CategoryScore[] = (
+    Object.keys(CATEGORY_LABELS) as Array<keyof typeof CATEGORY_LABELS>
+  ).map((id) => {
+    const stats = scoreFromChecks(byCat[id])
+    return {
+      id,
+      label: CATEGORY_LABELS[id],
+      ...stats,
+      checks: byCat[id],
+    }
+  })
+
+  const overall = scoreFromChecks(checks)
+  const fixFirst = [...checks]
+    .filter((c) => c.status !== "pass")
+    .sort((a, b) => statusOrder(a.status) - statusOrder(b.status))
+
+  return {
+    inputUrl: input.trim(),
+    origin,
+    finalUrl: homeRes.finalUrl || homeUrl,
+    domain,
+    auditedAt: new Date().toISOString(),
+    score: overall.score,
+    pass: overall.pass,
+    warn: overall.warn,
+    fail: overall.fail,
+    categories,
+    fixFirst,
+    domainRating: drRes.domainRating,
+    domainRatingError: drRes.error,
+  }
+}

--- a/lib/audit/run-audit.ts
+++ b/lib/audit/run-audit.ts
@@ -2,6 +2,7 @@ import { fetchDomainRating } from "@/lib/ahrefs-dr"
 import { fetchUrl, hostnameFromInput, normalizeOrigin } from "@/lib/fetch-url"
 import { expandSitemap } from "@/lib/sitemap-expand"
 import { parseHtml, parseSitemapLines } from "@/lib/audit/parse-html"
+import { sameRegistrableHost } from "@/lib/safe-url"
 import type {
   AuditCheck,
   AuditReport,
@@ -301,13 +302,21 @@ export async function runAudit(input: string): Promise<AuditReport> {
     deepLink: robotsDeep,
   })
 
+  const originHost = originUrl.hostname
   const sitemapCandidates = [
-    ...sitemapFromRobots,
+    ...sitemapFromRobots.filter((u) => {
+      try {
+        return sameRegistrableHost(new URL(u).hostname, originHost)
+      } catch {
+        return false
+      }
+    }),
     `${origin}/sitemap.xml`,
+    `${origin}/sitemap_index.xml`,
   ]
   const uniqueSitemaps = [...new Set(sitemapCandidates)]
 
-  let sitemapUrlUsed = uniqueSitemaps[0]
+  let sitemapUrlUsed = uniqueSitemaps[0] || `${origin}/sitemap.xml`
   let sitemapUrlCount = 0
   let sitemapTruncated = false
   let sitemapError: string | undefined
@@ -315,16 +324,28 @@ export async function runAudit(input: string): Promise<AuditReport> {
 
   for (const candidate of uniqueSitemaps) {
     try {
-      const expanded = await expandSitemap(candidate)
-      if (expanded.urls.length > 0 || expanded.rootKind !== "unknown") {
+      const expanded = await expandSitemap(candidate, {
+        maxDepth: 2,
+        maxChildSitemaps: 20,
+        maxPageUrls: 5_000,
+      })
+      // Prefer a candidate that yields page URLs; otherwise keep looking.
+      if (expanded.urls.length > 0) {
         sitemapUrlUsed = candidate
         sitemapUrlCount = expanded.urls.length
         sitemapTruncated = expanded.truncated
         sitemapExpanded = true
-        if (expanded.urls.length === 0 && expanded.childSitemapsFailed.length) {
+        break
+      }
+      if (!sitemapExpanded && expanded.rootKind !== "unknown") {
+        sitemapUrlUsed = candidate
+        sitemapUrlCount = 0
+        sitemapTruncated = expanded.truncated
+        sitemapExpanded = true
+        if (expanded.childSitemapsFailed.length) {
           sitemapError = expanded.childSitemapsFailed[0]?.reason
         }
-        break
+        // Continue searching for a candidate with real URLs.
       }
     } catch (err) {
       sitemapError = err instanceof Error ? err.message : "Expand failed"

--- a/lib/audit/types.ts
+++ b/lib/audit/types.ts
@@ -1,0 +1,40 @@
+export type CheckStatus = "pass" | "warn" | "fail"
+
+export type AuditCategoryId = "onpage" | "crawl" | "trust"
+
+export type AuditCheck = {
+  id: string
+  category: AuditCategoryId
+  label: string
+  status: CheckStatus
+  value?: string
+  detail: string
+  fixHint: string
+  deepLink?: string
+}
+
+export type CategoryScore = {
+  id: AuditCategoryId
+  label: string
+  score: number
+  pass: number
+  warn: number
+  fail: number
+  checks: AuditCheck[]
+}
+
+export type AuditReport = {
+  inputUrl: string
+  origin: string
+  finalUrl: string
+  domain: string
+  auditedAt: string
+  score: number
+  pass: number
+  warn: number
+  fail: number
+  categories: CategoryScore[]
+  fixFirst: AuditCheck[]
+  domainRating: number | null
+  domainRatingError?: string
+}

--- a/lib/blog-metadata.ts
+++ b/lib/blog-metadata.ts
@@ -1,0 +1,84 @@
+export type BlogPostMeta = {
+  title: string
+  description: string
+  date: string
+  category: string
+  readTime: string
+  coverImage: string
+  relatedTool: { href: string; label: string }
+}
+
+export const blogMetadata = {
+  "free-website-seo-audit": {
+    title: "How to Run a Free Website SEO Audit",
+    description:
+      "Learn what a free technical SEO audit should check — robots, sitemaps, meta tags, headers, and Domain Rating — and how to fix issues fast.",
+    date: "2026-07-15",
+    category: "Site Audit",
+    readTime: "7 min read",
+    coverImage: "/blog/audit.svg",
+    relatedTool: { href: "/audit?q=https://shrix1.com", label: "Run free audit" },
+  },
+  "what-is-domain-rating": {
+    title: "What Is Domain Rating? (And How to Check It Free)",
+    description:
+      "Domain Rating explained in plain language, plus how to look up Ahrefs DR for any domain without a paid subscription.",
+    date: "2026-07-15",
+    category: "Domain Rating",
+    readTime: "6 min read",
+    coverImage: "/blog/domain-rating.svg",
+    relatedTool: {
+      href: "/domain-rating?q=https://shrix1.com",
+      label: "Check Domain Rating",
+    },
+  },
+  "how-to-check-xml-sitemap": {
+    title: "How to Check an XML Sitemap (Including Indexes)",
+    description:
+      "Validate sitemap.xml and sitemap indexes, expand child sitemaps, and copy every page URL with a free checker.",
+    date: "2026-07-15",
+    category: "Sitemap",
+    readTime: "6 min read",
+    coverImage: "/blog/sitemap.svg",
+    relatedTool: {
+      href: "/sitemap?q=https://shrix1.com/sitemap.xml",
+      label: "Check sitemap",
+    },
+  },
+  "how-to-check-meta-tags": {
+    title: "How to Check Meta Tags and Social Previews",
+    description:
+      "Preview title, description, and Open Graph tags before you publish so search and social snippets look right.",
+    date: "2026-07-15",
+    category: "Metadata",
+    readTime: "5 min read",
+    coverImage: "/blog/metadata.svg",
+    relatedTool: {
+      href: "/metadata?q=https://shrix1.com",
+      label: "Check meta tags",
+    },
+  },
+  "how-to-check-robots-txt": {
+    title: "How to Check robots.txt (Without Breaking Crawl Access)",
+    description:
+      "Find robots.txt, read User-agent and Disallow rules, and confirm Sitemap directives with a free viewer.",
+    date: "2026-07-15",
+    category: "Robots",
+    readTime: "5 min read",
+    coverImage: "/blog/robots.svg",
+    relatedTool: {
+      href: "/robots?q=https://shrix1.com/robots.txt",
+      label: "Check robots.txt",
+    },
+  },
+} as const satisfies Record<string, BlogPostMeta>
+
+export type BlogSlug = keyof typeof blogMetadata
+
+export const blogSlugs = Object.keys(blogMetadata) as BlogSlug[]
+
+export function getBlogPosts() {
+  return blogSlugs
+    .map((slug) => ({ slug, ...blogMetadata[slug] }))
+    .sort((a, b) => (a.date < b.date ? 1 : -1))
+}

--- a/lib/blog-metadata.ts
+++ b/lib/blog-metadata.ts
@@ -6,23 +6,25 @@ export type BlogPostMeta = {
   readTime: string
   coverImage: string
   relatedTool: { href: string; label: string }
+  relatedLanding: { href: string; label: string }
 }
 
 export const blogMetadata = {
   "free-website-seo-audit": {
     title: "How to Run a Free Website SEO Audit",
     description:
-      "Learn what a free technical SEO audit should check — robots, sitemaps, meta tags, headers, and Domain Rating — and how to fix issues fast.",
+      "Learn what a free technical SEO audit should check — robots.txt, XML sitemaps, meta tags, security headers, and Ahrefs Domain Rating — plus how to prioritize and fix issues fast.",
     date: "2026-07-15",
     category: "Site Audit",
     readTime: "7 min read",
     coverImage: "/blog/audit.svg",
     relatedTool: { href: "/audit?q=https://shrix1.com", label: "Run free audit" },
+    relatedLanding: { href: "/site-audit", label: "Website SEO Audit" },
   },
   "what-is-domain-rating": {
     title: "What Is Domain Rating? (And How to Check It Free)",
     description:
-      "Domain Rating explained in plain language, plus how to look up Ahrefs DR for any domain without a paid subscription.",
+      "Domain Rating (DR) explained in plain language: what the Ahrefs score measures, why it matters for SEO, and how to look up DR for any domain free without a paid subscription.",
     date: "2026-07-15",
     category: "Domain Rating",
     readTime: "6 min read",
@@ -31,11 +33,15 @@ export const blogMetadata = {
       href: "/domain-rating?q=https://shrix1.com",
       label: "Check Domain Rating",
     },
+    relatedLanding: {
+      href: "/domain-rating-checker",
+      label: "Domain Rating Checker",
+    },
   },
   "how-to-check-xml-sitemap": {
     title: "How to Check an XML Sitemap (Including Indexes)",
     description:
-      "Validate sitemap.xml and sitemap indexes, expand child sitemaps, and copy every page URL with a free checker.",
+      "Learn how to validate sitemap.xml and sitemap indexes, expand nested child sitemaps, spot missing URLs, and copy every page URL with a free XML sitemap checker.",
     date: "2026-07-15",
     category: "Sitemap",
     readTime: "6 min read",
@@ -44,11 +50,12 @@ export const blogMetadata = {
       href: "/sitemap?q=https://shrix1.com/sitemap.xml",
       label: "Check sitemap",
     },
+    relatedLanding: { href: "/sitemap-checker", label: "XML Sitemap Checker" },
   },
   "how-to-check-meta-tags": {
     title: "How to Check Meta Tags and Social Previews",
     description:
-      "Preview title, description, and Open Graph tags before you publish so search and social snippets look right.",
+      "Learn how to check title tags, meta descriptions, and Open Graph social previews before you publish so Google and social snippets look right — with a free meta tags checker.",
     date: "2026-07-15",
     category: "Metadata",
     readTime: "5 min read",
@@ -57,11 +64,12 @@ export const blogMetadata = {
       href: "/metadata?q=https://shrix1.com",
       label: "Check meta tags",
     },
+    relatedLanding: { href: "/meta-tags-checker", label: "Meta Tags Checker" },
   },
   "how-to-check-robots-txt": {
     title: "How to Check robots.txt (Without Breaking Crawl Access)",
     description:
-      "Find robots.txt, read User-agent and Disallow rules, and confirm Sitemap directives with a free viewer.",
+      "Learn where robots.txt lives, how to read User-agent, Allow, and Disallow rules, and how to confirm Sitemap directives — without accidentally blocking crawl access.",
     date: "2026-07-15",
     category: "Robots",
     readTime: "5 min read",
@@ -70,6 +78,7 @@ export const blogMetadata = {
       href: "/robots?q=https://shrix1.com/robots.txt",
       label: "Check robots.txt",
     },
+    relatedLanding: { href: "/robots-txt-checker", label: "Robots.txt Checker" },
   },
 } as const satisfies Record<string, BlogPostMeta>
 

--- a/lib/client-ip.ts
+++ b/lib/client-ip.ts
@@ -1,0 +1,15 @@
+/** Best-effort client IP for rate limiting on Vercel / reverse proxies. */
+export function getClientIp(req: Request): string {
+  const realIp = req.headers.get("x-real-ip")?.trim()
+  if (realIp) return realIp
+
+  const forwarded = req.headers.get("x-forwarded-for")
+  if (forwarded) {
+    const parts = forwarded.split(",").map((p) => p.trim()).filter(Boolean)
+    // Prefer the rightmost hop (added by the trusted edge) over client-spoofable leftmost.
+    const edgeIp = parts[parts.length - 1]
+    if (edgeIp) return edgeIp
+  }
+
+  return "anonymous"
+}

--- a/lib/client-ip.ts
+++ b/lib/client-ip.ts
@@ -1,15 +1,17 @@
-/** Best-effort client IP for rate limiting on Vercel / reverse proxies. */
+/**
+ * Best-effort client IP for rate limiting.
+ * On Vercel, the leftmost X-Forwarded-For hop is the client IP set by the edge.
+ * Do not prefer client-supplied X-Real-IP over X-Forwarded-For.
+ */
 export function getClientIp(req: Request): string {
-  const realIp = req.headers.get("x-real-ip")?.trim()
-  if (realIp) return realIp
-
   const forwarded = req.headers.get("x-forwarded-for")
   if (forwarded) {
     const parts = forwarded.split(",").map((p) => p.trim()).filter(Boolean)
-    // Prefer the rightmost hop (added by the trusted edge) over client-spoofable leftmost.
-    const edgeIp = parts[parts.length - 1]
-    if (edgeIp) return edgeIp
+    if (parts[0]) return parts[0]
   }
+
+  const realIp = req.headers.get("x-real-ip")?.trim()
+  if (realIp) return realIp
 
   return "anonymous"
 }

--- a/lib/discord-webhook.ts
+++ b/lib/discord-webhook.ts
@@ -1,92 +1,67 @@
 const apiKey = {
-  id: process.env.NEXT_PUBLIC_DISCORD_LOGS_ID,
-  token: process.env.NEXT_PUBLIC_DISCORD_LOGS_TOKEN,
+  id: process.env.DISCORD_LOGS_ID ?? process.env.NEXT_PUBLIC_DISCORD_LOGS_ID,
+  token:
+    process.env.DISCORD_LOGS_TOKEN ?? process.env.NEXT_PUBLIC_DISCORD_LOGS_TOKEN,
 }
 const webhookApi = `https://discord.com/api/webhooks/${apiKey.id}/${apiKey.token}`
 
-export async function postDiscordLogs(
-  value: string,
-  type: "SITEMAP" | "METADATA"
-) {
+export type LogType = "SITEMAP" | "METADATA" | "ROBOTS"
+
+const logMeta: Record<
+  LogType,
+  { emoji: string; color: number; path: string }
+> = {
+  SITEMAP: {
+    emoji: "⌘",
+    color: 10181046,
+    path: "/sitemap",
+  },
+  METADATA: {
+    emoji: "🏞️",
+    color: 16776960,
+    path: "/metadata",
+  },
+  ROBOTS: {
+    emoji: "🤖",
+    color: 5763719,
+    path: "/robots",
+  },
+}
+
+/** Server-only Discord logger. Prefer DISCORD_LOGS_* env vars (not NEXT_PUBLIC_). */
+export async function postDiscordLogs(value: string, type: LogType) {
+  if (!apiKey.id || !apiKey.token) {
+    console.warn("Discord logs skipped: missing DISCORD_LOGS_ID/TOKEN")
+    return
+  }
+
+  const meta = logMeta[type]
   const data = {
-    content: `${type === "SITEMAP" ? "⌘" : "🏞️"} ${type} - ${value}`,
+    content: `${meta.emoji} ${type} - ${value}`,
     embeds: [
       {
         title: `**${value}** - ${type}`,
         description: ` **Time**: ${new Date().toLocaleTimeString()}
         **URL**: ${value}
           **Date**: ${new Date().toLocaleDateString()} 
-          **Browser**: ${getBrowserName()}
-          **OS**: ${getOperatingSystem()}
-          **Device**: ${isMobile() ? "Mobile" : "PC"}
-          **CHECK_HERE**:${
-            type === "SITEMAP"
-              ? `https://seocheckup.vercel.app/sitemap?q=${value}`
-              : `https://seocheckup.vercel.app/metadata?q=${value}`
-          }`,
-        color: type === "SITEMAP" ? 10181046 : 16776960,
+          **CHECK_HERE**:https://seocheckup.vercel.app${meta.path}?q=${encodeURIComponent(value)}`,
+        color: meta.color,
       },
     ],
   }
 
-  process.env.NODE_ENV === "development"
-    ? ""
-    : await fetch(webhookApi, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(data),
-      })
-        .then((response) => {
-          if (!response.ok) {
-            throw new Error(`HTTP error! Status: ${response.status}`)
-          }
-          return response.json()
-        })
-        .then((responseData) => {
-          console.log("Message sent successfully:", responseData)
-        })
-        .catch((error) => {
-          console.error("Error sending message to Discord:", error)
-        })
-}
+  if (process.env.NODE_ENV === "development") return
 
-function getBrowserName() {
-  const userAgent =
-    (typeof window !== "undefined" && navigator.userAgent) || ([] as any)
-  if (userAgent.indexOf("Firefox") !== -1) return "Firefox"
-  if (userAgent.indexOf("Chrome") !== -1) return "Chrome"
-  if (userAgent.indexOf("Safari") !== -1) return "Safari"
-  if (userAgent.indexOf("MSIE") !== -1 || userAgent.indexOf("Trident/") !== -1)
-    return "Internet Explorer"
-  if (userAgent.indexOf("Edge") !== -1) return "Edge"
-  if (userAgent.indexOf("Opera") !== -1 || userAgent.indexOf("OPR") !== -1)
-    return "Opera"
-  return "Unknown"
-}
-
-function getOperatingSystem() {
-  const platform =
-    (typeof window !== "undefined" && navigator.platform.toLowerCase()) ||
-    ([] as any)
-
-  if (platform.includes("win")) {
-    return "Windows"
-  } else if (platform.includes("mac")) {
-    return "Mac"
-  } else if (platform.includes("linux")) {
-    return "Linux"
-  } else {
-    return "Unknown"
+  try {
+    const response = await fetch(webhookApi, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    })
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`)
+    }
+  } catch (error) {
+    console.error("Error sending message to Discord:", error)
   }
-}
-
-function isMobile() {
-  return (
-    typeof window !== "undefined" &&
-    /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-      navigator.userAgent || (true as any)
-    )
-  )
 }

--- a/lib/discord-webhook.ts
+++ b/lib/discord-webhook.ts
@@ -5,7 +5,12 @@ const apiKey = {
 }
 const webhookApi = `https://discord.com/api/webhooks/${apiKey.id}/${apiKey.token}`
 
-export type LogType = "SITEMAP" | "METADATA" | "ROBOTS"
+export type LogType =
+  | "SITEMAP"
+  | "METADATA"
+  | "ROBOTS"
+  | "AUDIT"
+  | "DOMAIN_RATING"
 
 const logMeta: Record<
   LogType,
@@ -25,6 +30,16 @@ const logMeta: Record<
     emoji: "🤖",
     color: 5763719,
     path: "/robots",
+  },
+  AUDIT: {
+    emoji: "🩺",
+    color: 3447003,
+    path: "/audit",
+  },
+  DOMAIN_RATING: {
+    emoji: "📈",
+    color: 15844367,
+    path: "/domain-rating",
   },
 }
 

--- a/lib/fetch-url.ts
+++ b/lib/fetch-url.ts
@@ -1,0 +1,63 @@
+const FETCH_TIMEOUT_MS = 15_000
+const MAX_BODY_BYTES = 2_000_000
+
+export type FetchUrlResult = {
+  ok: boolean
+  status: number
+  finalUrl: string
+  headers: Headers
+  body: string
+  error?: string
+}
+
+export async function fetchUrl(url: string): Promise<FetchUrlResult> {
+  try {
+    const res = await fetch(url, {
+      redirect: "follow",
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: {
+        "User-Agent": "SeoCheckupBot/1.0 (+https://seocheckup.vercel.app)",
+        Accept: "*/*",
+      },
+    })
+
+    const text = await res.text()
+    const body =
+      text.length > MAX_BODY_BYTES ? text.slice(0, MAX_BODY_BYTES) : text
+
+    return {
+      ok: res.ok,
+      status: res.status,
+      finalUrl: res.url || url,
+      headers: res.headers,
+      body,
+      error: res.ok ? undefined : `HTTP ${res.status}`,
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      status: 0,
+      finalUrl: url,
+      headers: new Headers(),
+      body: "",
+      error: err instanceof Error ? err.message : "Fetch failed",
+    }
+  }
+}
+
+export function normalizeOrigin(input: string): URL {
+  let raw = input.trim()
+  if (!/^https?:\/\//i.test(raw)) {
+    raw = `https://${raw}`
+  }
+  const url = new URL(raw)
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Only http and https URLs are allowed")
+  }
+  return new URL(`${url.protocol}//${url.host}`)
+}
+
+export function hostnameFromInput(input: string): string {
+  const origin = normalizeOrigin(input)
+  return origin.hostname.replace(/^www\./i, "")
+}

--- a/lib/fetch-url.ts
+++ b/lib/fetch-url.ts
@@ -1,5 +1,4 @@
-const FETCH_TIMEOUT_MS = 15_000
-const MAX_BODY_BYTES = 2_000_000
+import { safeFetch } from "@/lib/safe-fetch"
 
 export type FetchUrlResult = {
   ok: boolean
@@ -11,37 +10,14 @@ export type FetchUrlResult = {
 }
 
 export async function fetchUrl(url: string): Promise<FetchUrlResult> {
-  try {
-    const res = await fetch(url, {
-      redirect: "follow",
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-      headers: {
-        "User-Agent": "SeoCheckupBot/1.0 (+https://seocheckup.vercel.app)",
-        Accept: "*/*",
-      },
-    })
-
-    const text = await res.text()
-    const body =
-      text.length > MAX_BODY_BYTES ? text.slice(0, MAX_BODY_BYTES) : text
-
-    return {
-      ok: res.ok,
-      status: res.status,
-      finalUrl: res.url || url,
-      headers: res.headers,
-      body,
-      error: res.ok ? undefined : `HTTP ${res.status}`,
-    }
-  } catch (err) {
-    return {
-      ok: false,
-      status: 0,
-      finalUrl: url,
-      headers: new Headers(),
-      body: "",
-      error: err instanceof Error ? err.message : "Fetch failed",
-    }
+  const res = await safeFetch(url)
+  return {
+    ok: res.ok,
+    status: res.status,
+    finalUrl: res.finalUrl,
+    headers: res.headers,
+    body: res.body.toString("utf8"),
+    error: res.error,
   }
 }
 

--- a/lib/log-tool-usage.ts
+++ b/lib/log-tool-usage.ts
@@ -1,0 +1,14 @@
+export type ClientLogType = "SITEMAP" | "METADATA" | "ROBOTS"
+
+/** Client-safe helper: posts via server route so webhook secrets stay server-side. */
+export async function logToolUsage(value: string, type: ClientLogType) {
+  try {
+    await fetch("/api/logs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value, type }),
+    })
+  } catch (error) {
+    console.error("Error logging tool usage:", error)
+  }
+}

--- a/lib/log-tool-usage.ts
+++ b/lib/log-tool-usage.ts
@@ -1,4 +1,9 @@
-export type ClientLogType = "SITEMAP" | "METADATA" | "ROBOTS"
+export type ClientLogType =
+  | "SITEMAP"
+  | "METADATA"
+  | "ROBOTS"
+  | "AUDIT"
+  | "DOMAIN_RATING"
 
 /** Client-safe helper: posts via server route so webhook secrets stay server-side. */
 export async function logToolUsage(value: string, type: ClientLogType) {

--- a/lib/log-tool-usage.ts
+++ b/lib/log-tool-usage.ts
@@ -1,3 +1,7 @@
+/**
+ * @deprecated Client Discord logging is disabled.
+ * Tool APIs log server-side after successful requests.
+ */
 export type ClientLogType =
   | "SITEMAP"
   | "METADATA"
@@ -5,15 +9,6 @@ export type ClientLogType =
   | "AUDIT"
   | "DOMAIN_RATING"
 
-/** Client-safe helper: posts via server route so webhook secrets stay server-side. */
-export async function logToolUsage(value: string, type: ClientLogType) {
-  try {
-    await fetch("/api/logs", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ value, type }),
-    })
-  } catch (error) {
-    console.error("Error logging tool usage:", error)
-  }
+export async function logToolUsage(_value: string, _type: ClientLogType) {
+  // no-op — kept for import safety during migration
 }

--- a/lib/safe-decode.ts
+++ b/lib/safe-decode.ts
@@ -1,0 +1,8 @@
+export function safeDecodeURIComponent(value: string | undefined | null): string {
+  if (!value) return ""
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}

--- a/lib/safe-fetch.ts
+++ b/lib/safe-fetch.ts
@@ -1,0 +1,134 @@
+import { assertPublicHttpUrl } from "@/lib/safe-url"
+
+const FETCH_TIMEOUT_MS = 15_000
+const MAX_BODY_BYTES = 2_000_000
+const MAX_REDIRECTS = 5
+
+export type SafeFetchResult = {
+  ok: boolean
+  status: number
+  finalUrl: string
+  headers: Headers
+  body: Buffer
+  error?: string
+}
+
+async function readBodyLimited(
+  res: Response,
+  maxBytes: number
+): Promise<Buffer> {
+  if (!res.body) return Buffer.alloc(0)
+
+  const reader = res.body.getReader()
+  const chunks: Buffer[] = []
+  let total = 0
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (!value) continue
+
+    const nextTotal = total + value.byteLength
+    if (nextTotal > maxBytes) {
+      const allowed = maxBytes - total
+      if (allowed > 0) chunks.push(Buffer.from(value.subarray(0, allowed)))
+      await reader.cancel().catch(() => undefined)
+      break
+    }
+
+    chunks.push(Buffer.from(value))
+    total = nextTotal
+  }
+
+  return chunks.length ? Buffer.concat(chunks) : Buffer.alloc(0)
+}
+
+export async function safeFetch(
+  input: string,
+  init?: {
+    headers?: HeadersInit
+    timeoutMs?: number
+    maxBytes?: number
+  }
+): Promise<SafeFetchResult> {
+  const timeoutMs = init?.timeoutMs ?? FETCH_TIMEOUT_MS
+  const maxBytes = init?.maxBytes ?? MAX_BODY_BYTES
+  let current = input
+
+  try {
+    for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      const url = await assertPublicHttpUrl(current)
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+      let res: Response
+      try {
+        res = await fetch(url.href, {
+          redirect: "manual",
+          signal: controller.signal,
+          headers: {
+            "User-Agent": "SeoCheckupBot/1.0 (+https://seocheckup.vercel.app)",
+            Accept: "*/*",
+            ...(init?.headers || {}),
+          },
+        })
+      } finally {
+        clearTimeout(timer)
+      }
+
+      if (res.status >= 300 && res.status < 400) {
+        const location = res.headers.get("location")
+        if (!location) {
+          return {
+            ok: false,
+            status: res.status,
+            finalUrl: url.href,
+            headers: res.headers,
+            body: Buffer.alloc(0),
+            error: "Redirect missing Location",
+          }
+        }
+        current = new URL(location, url).href
+        if (hop === MAX_REDIRECTS) {
+          return {
+            ok: false,
+            status: res.status,
+            finalUrl: current,
+            headers: res.headers,
+            body: Buffer.alloc(0),
+            error: "Too many redirects",
+          }
+        }
+        continue
+      }
+
+      const body = await readBodyLimited(res, maxBytes)
+      return {
+        ok: res.ok,
+        status: res.status,
+        finalUrl: url.href,
+        headers: res.headers,
+        body,
+        error: res.ok ? undefined : `HTTP ${res.status}`,
+      }
+    }
+
+    return {
+      ok: false,
+      status: 0,
+      finalUrl: current,
+      headers: new Headers(),
+      body: Buffer.alloc(0),
+      error: "Too many redirects",
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      status: 0,
+      finalUrl: current,
+      headers: new Headers(),
+      body: Buffer.alloc(0),
+      error: err instanceof Error ? err.message : "Fetch failed",
+    }
+  }
+}

--- a/lib/safe-url.ts
+++ b/lib/safe-url.ts
@@ -1,0 +1,126 @@
+import dns from "node:dns/promises"
+import net from "node:net"
+
+const ALLOWED_PORTS = new Set([80, 443, ""])
+
+const blockV4 = new net.BlockList()
+blockV4.addSubnet("0.0.0.0", 8, "ipv4")
+blockV4.addSubnet("10.0.0.0", 8, "ipv4")
+blockV4.addSubnet("127.0.0.0", 8, "ipv4")
+blockV4.addSubnet("169.254.0.0", 16, "ipv4")
+blockV4.addSubnet("172.16.0.0", 12, "ipv4")
+blockV4.addSubnet("192.168.0.0", 16, "ipv4")
+blockV4.addSubnet("100.64.0.0", 10, "ipv4")
+blockV4.addSubnet("192.0.0.0", 24, "ipv4")
+blockV4.addSubnet("192.0.2.0", 24, "ipv4")
+blockV4.addSubnet("198.18.0.0", 15, "ipv4")
+blockV4.addSubnet("198.51.100.0", 24, "ipv4")
+blockV4.addSubnet("203.0.113.0", 24, "ipv4")
+blockV4.addSubnet("224.0.0.0", 4, "ipv4")
+blockV4.addSubnet("240.0.0.0", 4, "ipv4")
+
+const blockV6 = new net.BlockList()
+blockV6.addSubnet("::1", 128, "ipv6")
+blockV6.addSubnet("::", 128, "ipv6")
+blockV6.addSubnet("fc00::", 7, "ipv6")
+blockV6.addSubnet("fe80::", 10, "ipv6")
+blockV6.addSubnet("ff00::", 8, "ipv6")
+
+const BLOCKED_HOSTNAMES = new Set([
+  "localhost",
+  "metadata.google.internal",
+  "metadata.goog",
+  "kubernetes.default",
+  "kubernetes.default.svc",
+])
+
+function ipv4FromMapped(ip: string): string | null {
+  const lower = ip.toLowerCase()
+  if (!lower.startsWith("::ffff:")) return null
+  const rest = lower.slice("::ffff:".length)
+  if (net.isIPv4(rest)) return rest
+  // Hex form ::ffff:a9fe:a9fe
+  const hex = rest.match(/^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i)
+  if (!hex) return null
+  const hi = parseInt(hex[1], 16)
+  const lo = parseInt(hex[2], 16)
+  return `${(hi >> 8) & 255}.${hi & 255}.${(lo >> 8) & 255}.${lo & 255}`
+}
+
+export function isBlockedIp(ip: string): boolean {
+  const trimmed = ip.trim().replace(/^\[|\]$/g, "")
+  const mapped = ipv4FromMapped(trimmed)
+  if (mapped) return blockV4.check(mapped, "ipv4")
+  if (net.isIPv4(trimmed)) return blockV4.check(trimmed, "ipv4")
+  if (net.isIPv6(trimmed)) return blockV6.check(trimmed, "ipv6")
+  return true
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/\.$/, "")
+  if (!host) return true
+  if (BLOCKED_HOSTNAMES.has(host)) return true
+  if (host.endsWith(".localhost") || host.endsWith(".local")) return true
+  if (host.endsWith(".internal") || host.endsWith(".intranet")) return true
+  if (host.endsWith(".lan") || host.endsWith(".home")) return true
+  return false
+}
+
+export async function assertPublicHttpUrl(input: string | URL): Promise<URL> {
+  let url: URL
+  try {
+    url = typeof input === "string" ? new URL(input) : new URL(input.href)
+  } catch {
+    throw new Error("Invalid URL")
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Only http and https URLs are allowed")
+  }
+
+  if (url.username || url.password) {
+    throw new Error("URLs with credentials are not allowed")
+  }
+
+  const port = url.port || ""
+  if (!ALLOWED_PORTS.has(port)) {
+    throw new Error("Only ports 80 and 443 are allowed")
+  }
+
+  const hostname = url.hostname.replace(/^\[|\]$/g, "")
+  if (isBlockedHostname(hostname)) {
+    throw new Error("Host is not allowed")
+  }
+
+  if (net.isIP(hostname)) {
+    if (isBlockedIp(hostname)) {
+      throw new Error("Private or reserved IP addresses are not allowed")
+    }
+    return url
+  }
+
+  let records: { address: string; family: number }[]
+  try {
+    records = await dns.lookup(hostname, { all: true, verbatim: true })
+  } catch {
+    throw new Error("DNS lookup failed")
+  }
+
+  if (!records.length) {
+    throw new Error("DNS lookup returned no addresses")
+  }
+
+  for (const record of records) {
+    if (isBlockedIp(record.address)) {
+      throw new Error("Host resolves to a private or reserved address")
+    }
+  }
+
+  return url
+}
+
+export function sameRegistrableHost(a: string, b: string): boolean {
+  const normalize = (host: string) =>
+    host.toLowerCase().replace(/^\[|\]$/g, "").replace(/^www\./, "")
+  return normalize(a) === normalize(b)
+}

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,0 +1,88 @@
+export const SITE_URL = "https://seocheckup.vercel.app"
+
+export type FeatureKey =
+  | "audit"
+  | "domainRating"
+  | "sitemap"
+  | "metadata"
+  | "robots"
+
+export type FeatureRoutes = {
+  toolPath: string
+  landingPath: string
+  blogSlug: string
+  toolLabel: string
+  landingLabel: string
+  blogLabel: string
+  appName: string
+  description: string
+}
+
+/** Canonical tool ↔ PSEO landing ↔ blog guide graph */
+export const features: Record<FeatureKey, FeatureRoutes> = {
+  audit: {
+    toolPath: "/audit",
+    landingPath: "/site-audit",
+    blogSlug: "free-website-seo-audit",
+    toolLabel: "Site Audit",
+    landingLabel: "Website SEO Audit",
+    blogLabel: "How to run a free SEO audit",
+    appName: "Website SEO Audit",
+    description:
+      "Run a free technical SEO audit on any URL: on-page title and meta, robots.txt, XML sitemaps, security headers, and Ahrefs Domain Rating — unlocked results, no account.",
+  },
+  domainRating: {
+    toolPath: "/domain-rating",
+    landingPath: "/domain-rating-checker",
+    blogSlug: "what-is-domain-rating",
+    toolLabel: "Domain Rating",
+    landingLabel: "Domain Rating Checker",
+    blogLabel: "What is Domain Rating?",
+    appName: "Domain Rating Checker",
+    description:
+      "Look up Ahrefs Domain Rating (DR) for any domain free. Instant backlink-authority score from Ahrefs’ public endpoint, with required Domain Rating by Ahrefs attribution.",
+  },
+  sitemap: {
+    toolPath: "/sitemap",
+    landingPath: "/sitemap-checker",
+    blogSlug: "how-to-check-xml-sitemap",
+    toolLabel: "Sitemap Checker",
+    landingLabel: "XML Sitemap Checker",
+    blogLabel: "How to check an XML sitemap",
+    appName: "XML Sitemap Checker",
+    description:
+      "Paste a sitemap.xml or sitemap index URL to expand child sitemaps, list every page URL, filter by source, and copy the full URL list — free XML sitemap checker.",
+  },
+  metadata: {
+    toolPath: "/metadata",
+    landingPath: "/meta-tags-checker",
+    blogSlug: "how-to-check-meta-tags",
+    toolLabel: "Meta Tags Checker",
+    landingLabel: "Meta Tags Checker",
+    blogLabel: "How to check meta tags",
+    appName: "Meta Tags Checker",
+    description:
+      "Preview a page’s title, meta description, and Open Graph tags before you publish. Free meta tags checker for search snippets and social share cards.",
+  },
+  robots: {
+    toolPath: "/robots",
+    landingPath: "/robots-txt-checker",
+    blogSlug: "how-to-check-robots-txt",
+    toolLabel: "Robots.txt Viewer",
+    landingLabel: "Robots.txt Checker",
+    blogLabel: "How to check robots.txt",
+    appName: "Robots.txt Checker",
+    description:
+      "Fetch any public robots.txt and highlight User-agent, Allow, Disallow, and Sitemap directives so you can confirm crawl access without guessing.",
+  },
+}
+
+export function absoluteUrl(path: string) {
+  if (path.startsWith("http")) return path
+  const normalized = path.startsWith("/") ? path : `/${path}`
+  return `${SITE_URL}${normalized === "/" ? "" : normalized}` || SITE_URL
+}
+
+export function blogPath(slug: string) {
+  return `/blog/${slug}`
+}

--- a/lib/sitemap-expand.ts
+++ b/lib/sitemap-expand.ts
@@ -1,0 +1,264 @@
+import { gunzipSync } from "node:zlib"
+
+const MAX_DEPTH = 3
+const MAX_CHILD_SITEMAPS = 100
+const MAX_PAGE_URLS = 50_000
+const CONCURRENCY = 4
+const FETCH_TIMEOUT_MS = 15_000
+const MAX_BODY_BYTES = 2_000_000
+
+export type SitemapKind = "urlset" | "sitemapindex" | "unknown"
+
+export type ExpandResult = {
+  urls: string[]
+  rootKind: SitemapKind
+  childSitemapsFetched: number
+  childSitemapsFailed: { url: string; reason: string }[]
+  truncated: boolean
+}
+
+type ParseResult = {
+  kind: SitemapKind
+  locs: string[]
+}
+
+function decodeXmlEntities(value: string): string {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+}
+
+function normalizeHost(hostname: string): string {
+  return hostname.toLowerCase().replace(/^www\./, "")
+}
+
+function sameSite(root: URL, candidate: URL): boolean {
+  return normalizeHost(root.hostname) === normalizeHost(candidate.hostname)
+}
+
+function isHttpUrl(url: URL): boolean {
+  return url.protocol === "http:" || url.protocol === "https:"
+}
+
+export function parseSitemapXml(xml: string): ParseResult {
+  const rootMatch = xml.match(/<(?:[A-Za-z_][\w.-]*:)?(sitemapindex|urlset)\b/i)
+  const root = rootMatch?.[1]?.toLowerCase()
+
+  if (root === "sitemapindex") {
+    const locs: string[] = []
+    const blocks = xml.matchAll(
+      /<(?:[A-Za-z_][\w.-]*:)?sitemap\b[^>]*>[\s\S]*?<\/(?:[A-Za-z_][\w.-]*:)?sitemap>/gi
+    )
+    for (const block of blocks) {
+      const locMatch = block[0].match(
+        /<(?:[A-Za-z_][\w.-]*:)?loc\b[^>]*>\s*([^<]+?)\s*<\/(?:[A-Za-z_][\w.-]*:)?loc>/i
+      )
+      if (locMatch?.[1]) {
+        locs.push(decodeXmlEntities(locMatch[1].trim()))
+      }
+    }
+    return { kind: "sitemapindex", locs }
+  }
+
+  if (root === "urlset") {
+    const locs: string[] = []
+    const blocks = xml.matchAll(
+      /<(?:[A-Za-z_][\w.-]*:)?url\b[^>]*>[\s\S]*?<\/(?:[A-Za-z_][\w.-]*:)?url>/gi
+    )
+    for (const block of blocks) {
+      const locMatch = block[0].match(
+        /<(?:[A-Za-z_][\w.-]*:)?loc\b[^>]*>\s*([^<]+?)\s*<\/(?:[A-Za-z_][\w.-]*:)?loc>/i
+      )
+      if (locMatch?.[1]) {
+        locs.push(decodeXmlEntities(locMatch[1].trim()))
+      }
+    }
+    return { kind: "urlset", locs }
+  }
+
+  return { kind: "unknown", locs: [] }
+}
+
+async function fetchSitemapBody(url: string): Promise<string> {
+  const res = await fetch(url, {
+    redirect: "follow",
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    headers: {
+      Accept: "application/xml,text/xml,application/gzip,*/*",
+    },
+  })
+
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`)
+  }
+
+  const buffer = Buffer.from(await res.arrayBuffer())
+  const capped = buffer.subarray(0, MAX_BODY_BYTES)
+  const encoding = (res.headers.get("content-encoding") || "").toLowerCase()
+  const looksGzip =
+    url.toLowerCase().endsWith(".gz") ||
+    encoding.includes("gzip") ||
+    (capped.length >= 2 && capped[0] === 0x1f && capped[1] === 0x8b)
+
+  if (looksGzip) {
+    try {
+      return gunzipSync(capped).toString("utf8")
+    } catch {
+      // Some servers label incorrectly; fall through to utf8 text.
+    }
+  }
+
+  return capped.toString("utf8")
+}
+
+async function mapPool<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length)
+  let next = 0
+
+  async function run() {
+    while (next < items.length) {
+      const index = next++
+      results[index] = await worker(items[index])
+    }
+  }
+
+  const runners = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    () => run()
+  )
+  await Promise.all(runners)
+  return results
+}
+
+export async function expandSitemap(rootUrl: string): Promise<ExpandResult> {
+  const rootParsed = new URL(rootUrl)
+  if (!isHttpUrl(rootParsed)) {
+    throw new Error("Only http and https URLs are allowed")
+  }
+
+  const pageUrls = new Set<string>()
+  const visited = new Set<string>()
+  const failed: { url: string; reason: string }[] = []
+  let childSitemapsFetched = 0
+  let truncated = false
+  let rootKind: SitemapKind = "unknown"
+
+  type QueueItem = { url: string; depth: number }
+  const queue: QueueItem[] = [{ url: rootParsed.href, depth: 0 }]
+
+  while (queue.length > 0) {
+    if (pageUrls.size >= MAX_PAGE_URLS) {
+      truncated = true
+      break
+    }
+
+    const batch: QueueItem[] = []
+    while (queue.length > 0 && batch.length < CONCURRENCY) {
+      const item = queue.shift()!
+      if (visited.has(item.url)) continue
+      visited.add(item.url)
+      batch.push(item)
+    }
+
+    if (batch.length === 0) continue
+
+    const batchResults = await mapPool(batch, CONCURRENCY, async (item) => {
+      try {
+        const xml = await fetchSitemapBody(item.url)
+        const parsed = parseSitemapXml(xml)
+        return { item, parsed, error: null as string | null }
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : "Fetch failed"
+        return { item, parsed: null, error: reason }
+      }
+    })
+
+    for (const result of batchResults) {
+      if (result.error || !result.parsed) {
+        failed.push({
+          url: result.item.url,
+          reason: result.error || "Parse failed",
+        })
+        continue
+      }
+
+      const { item, parsed } = result
+      if (item.depth === 0) {
+        rootKind = parsed.kind
+      } else {
+        childSitemapsFetched += 1
+      }
+
+      if (parsed.kind === "urlset") {
+        for (const loc of parsed.locs) {
+          if (pageUrls.size >= MAX_PAGE_URLS) {
+            truncated = true
+            break
+          }
+          try {
+            const locUrl = new URL(loc)
+            if (isHttpUrl(locUrl)) {
+              pageUrls.add(locUrl.href)
+            }
+          } catch {
+            // skip invalid page URL
+          }
+        }
+        continue
+      }
+
+      if (parsed.kind === "sitemapindex") {
+        if (item.depth >= MAX_DEPTH) {
+          truncated = true
+          continue
+        }
+
+        let accepted = 0
+        for (const loc of parsed.locs) {
+          if (visited.size + queue.length + accepted >= MAX_CHILD_SITEMAPS + 1) {
+            truncated = true
+            break
+          }
+          try {
+            const childUrl = new URL(loc)
+            if (!isHttpUrl(childUrl)) continue
+            if (!sameSite(rootParsed, childUrl)) {
+              failed.push({
+                url: childUrl.href,
+                reason: "Cross-host sitemap skipped",
+              })
+              continue
+            }
+            if (!visited.has(childUrl.href)) {
+              queue.push({ url: childUrl.href, depth: item.depth + 1 })
+              accepted += 1
+            }
+          } catch {
+            failed.push({ url: loc, reason: "Invalid child sitemap URL" })
+          }
+        }
+        continue
+      }
+
+      failed.push({
+        url: item.url,
+        reason: "Unrecognized sitemap XML root",
+      })
+    }
+  }
+
+  return {
+    urls: Array.from(pageUrls),
+    rootKind,
+    childSitemapsFetched,
+    childSitemapsFailed: failed,
+    truncated,
+  }
+}

--- a/lib/sitemap-expand.ts
+++ b/lib/sitemap-expand.ts
@@ -1,11 +1,17 @@
 import { gunzipSync } from "node:zlib"
+import { safeFetch } from "@/lib/safe-fetch"
 
-const MAX_DEPTH = 3
-const MAX_CHILD_SITEMAPS = 100
-const MAX_PAGE_URLS = 50_000
+const DEFAULT_MAX_DEPTH = 3
+const DEFAULT_MAX_CHILD_SITEMAPS = 100
+const DEFAULT_MAX_PAGE_URLS = 50_000
 const CONCURRENCY = 4
-const FETCH_TIMEOUT_MS = 15_000
 const MAX_BODY_BYTES = 2_000_000
+
+export type ExpandOptions = {
+  maxDepth?: number
+  maxChildSitemaps?: number
+  maxPageUrls?: number
+}
 
 export type SitemapKind = "urlset" | "sitemapindex" | "unknown"
 
@@ -92,20 +98,18 @@ export function parseSitemapXml(xml: string): ParseResult {
 }
 
 async function fetchSitemapBody(url: string): Promise<string> {
-  const res = await fetch(url, {
-    redirect: "follow",
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  const res = await safeFetch(url, {
     headers: {
       Accept: "application/xml,text/xml,application/gzip,*/*",
     },
+    maxBytes: MAX_BODY_BYTES,
   })
 
   if (!res.ok) {
-    throw new Error(`HTTP ${res.status}`)
+    throw new Error(res.error || `HTTP ${res.status}`)
   }
 
-  const buffer = Buffer.from(await res.arrayBuffer())
-  const capped = buffer.subarray(0, MAX_BODY_BYTES)
+  const capped = res.body
   const encoding = (res.headers.get("content-encoding") || "").toLowerCase()
   const looksGzip =
     url.toLowerCase().endsWith(".gz") ||
@@ -114,7 +118,9 @@ async function fetchSitemapBody(url: string): Promise<string> {
 
   if (looksGzip) {
     try {
-      return gunzipSync(capped).toString("utf8")
+      return gunzipSync(capped, { maxOutputLength: MAX_BODY_BYTES }).toString(
+        "utf8"
+      )
     } catch {
       // Some servers label incorrectly; fall through to utf8 text.
     }
@@ -172,7 +178,14 @@ function collectPageUrls(
   return { urls, truncated }
 }
 
-export async function expandSitemap(rootUrl: string): Promise<ExpandResult> {
+export async function expandSitemap(
+  rootUrl: string,
+  options: ExpandOptions = {}
+): Promise<ExpandResult> {
+  const maxDepth = options.maxDepth ?? DEFAULT_MAX_DEPTH
+  const maxChildSitemaps = options.maxChildSitemaps ?? DEFAULT_MAX_CHILD_SITEMAPS
+  const maxPageUrls = options.maxPageUrls ?? DEFAULT_MAX_PAGE_URLS
+
   const rootParsed = new URL(rootUrl)
   if (!isHttpUrl(rootParsed)) {
     throw new Error("Only http and https URLs are allowed")
@@ -191,7 +204,7 @@ export async function expandSitemap(rootUrl: string): Promise<ExpandResult> {
   const queue: QueueItem[] = [{ url: indexUrl, depth: 0 }]
 
   while (queue.length > 0) {
-    if (pageUrls.size >= MAX_PAGE_URLS) {
+    if (pageUrls.size >= maxPageUrls) {
       truncated = true
       break
     }
@@ -245,7 +258,7 @@ export async function expandSitemap(rootUrl: string): Promise<ExpandResult> {
         const { urls: sourceUrls, truncated: hitCap } = collectPageUrls(
           parsed.locs,
           pageUrls,
-          MAX_PAGE_URLS
+          maxPageUrls
         )
         for (const u of sourceUrls) pageUrls.add(u)
         sources.push({
@@ -258,14 +271,14 @@ export async function expandSitemap(rootUrl: string): Promise<ExpandResult> {
       }
 
       if (parsed.kind === "sitemapindex") {
-        if (item.depth >= MAX_DEPTH) {
+        if (item.depth >= maxDepth) {
           truncated = true
           continue
         }
 
         let accepted = 0
         for (const loc of parsed.locs) {
-          if (visited.size + queue.length + accepted >= MAX_CHILD_SITEMAPS + 1) {
+          if (visited.size + queue.length + accepted >= maxChildSitemaps + 1) {
             truncated = true
             break
           }

--- a/lib/sitemap-expand.ts
+++ b/lib/sitemap-expand.ts
@@ -9,9 +9,18 @@ const MAX_BODY_BYTES = 2_000_000
 
 export type SitemapKind = "urlset" | "sitemapindex" | "unknown"
 
+export type SitemapSource = {
+  sitemapUrl: string
+  urlCount: number
+  urls: string[]
+  error?: string
+}
+
 export type ExpandResult = {
+  indexUrl: string
   urls: string[]
   rootKind: SitemapKind
+  sources: SitemapSource[]
   childSitemapsFetched: number
   childSitemapsFailed: { url: string; reason: string }[]
   truncated: boolean
@@ -137,21 +146,49 @@ async function mapPool<T, R>(
   return results
 }
 
+function collectPageUrls(
+  locs: string[],
+  pageUrls: Set<string>,
+  remaining: number
+): { urls: string[]; truncated: boolean } {
+  const urls: string[] = []
+  let truncated = false
+
+  for (const loc of locs) {
+    if (pageUrls.size + urls.length >= remaining) {
+      truncated = true
+      break
+    }
+    try {
+      const locUrl = new URL(loc)
+      if (!isHttpUrl(locUrl)) continue
+      if (pageUrls.has(locUrl.href) || urls.includes(locUrl.href)) continue
+      urls.push(locUrl.href)
+    } catch {
+      // skip invalid page URL
+    }
+  }
+
+  return { urls, truncated }
+}
+
 export async function expandSitemap(rootUrl: string): Promise<ExpandResult> {
   const rootParsed = new URL(rootUrl)
   if (!isHttpUrl(rootParsed)) {
     throw new Error("Only http and https URLs are allowed")
   }
 
+  const indexUrl = rootParsed.href
   const pageUrls = new Set<string>()
   const visited = new Set<string>()
+  const sources: SitemapSource[] = []
   const failed: { url: string; reason: string }[] = []
   let childSitemapsFetched = 0
   let truncated = false
   let rootKind: SitemapKind = "unknown"
 
   type QueueItem = { url: string; depth: number }
-  const queue: QueueItem[] = [{ url: rootParsed.href, depth: 0 }]
+  const queue: QueueItem[] = [{ url: indexUrl, depth: 0 }]
 
   while (queue.length > 0) {
     if (pageUrls.size >= MAX_PAGE_URLS) {
@@ -182,10 +219,18 @@ export async function expandSitemap(rootUrl: string): Promise<ExpandResult> {
 
     for (const result of batchResults) {
       if (result.error || !result.parsed) {
-        failed.push({
-          url: result.item.url,
-          reason: result.error || "Parse failed",
-        })
+        const reason = result.error || "Parse failed"
+        failed.push({ url: result.item.url, reason })
+        // Only record failed leaf/child sources (not the root index itself as a source with error
+        // when depth > 0, or when root fails entirely)
+        if (result.item.depth > 0 || rootKind === "unknown") {
+          sources.push({
+            sitemapUrl: result.item.url,
+            urlCount: 0,
+            urls: [],
+            error: reason,
+          })
+        }
         continue
       }
 
@@ -197,20 +242,18 @@ export async function expandSitemap(rootUrl: string): Promise<ExpandResult> {
       }
 
       if (parsed.kind === "urlset") {
-        for (const loc of parsed.locs) {
-          if (pageUrls.size >= MAX_PAGE_URLS) {
-            truncated = true
-            break
-          }
-          try {
-            const locUrl = new URL(loc)
-            if (isHttpUrl(locUrl)) {
-              pageUrls.add(locUrl.href)
-            }
-          } catch {
-            // skip invalid page URL
-          }
-        }
+        const { urls: sourceUrls, truncated: hitCap } = collectPageUrls(
+          parsed.locs,
+          pageUrls,
+          MAX_PAGE_URLS
+        )
+        for (const u of sourceUrls) pageUrls.add(u)
+        sources.push({
+          sitemapUrl: item.url,
+          urlCount: sourceUrls.length,
+          urls: sourceUrls,
+        })
+        if (hitCap) truncated = true
         continue
       }
 
@@ -230,9 +273,13 @@ export async function expandSitemap(rootUrl: string): Promise<ExpandResult> {
             const childUrl = new URL(loc)
             if (!isHttpUrl(childUrl)) continue
             if (!sameSite(rootParsed, childUrl)) {
-              failed.push({
-                url: childUrl.href,
-                reason: "Cross-host sitemap skipped",
+              const reason = "Cross-host sitemap skipped"
+              failed.push({ url: childUrl.href, reason })
+              sources.push({
+                sitemapUrl: childUrl.href,
+                urlCount: 0,
+                urls: [],
+                error: reason,
               })
               continue
             }
@@ -241,22 +288,48 @@ export async function expandSitemap(rootUrl: string): Promise<ExpandResult> {
               accepted += 1
             }
           } catch {
-            failed.push({ url: loc, reason: "Invalid child sitemap URL" })
+            const reason = "Invalid child sitemap URL"
+            failed.push({ url: loc, reason })
+            sources.push({
+              sitemapUrl: loc,
+              urlCount: 0,
+              urls: [],
+              error: reason,
+            })
           }
         }
         continue
       }
 
-      failed.push({
-        url: item.url,
-        reason: "Unrecognized sitemap XML root",
+      const reason = "Unrecognized sitemap XML root"
+      failed.push({ url: item.url, reason })
+      sources.push({
+        sitemapUrl: item.url,
+        urlCount: 0,
+        urls: [],
+        error: reason,
       })
     }
   }
 
+  // Deduplicate sources by sitemapUrl (keep first successful, or last error)
+  const byUrl = new Map<string, SitemapSource>()
+  for (const source of sources) {
+    const existing = byUrl.get(source.sitemapUrl)
+    if (!existing) {
+      byUrl.set(source.sitemapUrl, source)
+      continue
+    }
+    if (existing.error && !source.error) {
+      byUrl.set(source.sitemapUrl, source)
+    }
+  }
+
   return {
+    indexUrl,
     urls: Array.from(pageUrls),
     rootKind,
+    sources: Array.from(byUrl.values()),
     childSitemapsFetched,
     childSitemapsFailed: failed,
     truncated,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -30,8 +30,9 @@ export function getSitemapBaseUrl(sitemapUrl: string): string {
 }
 
 export function constructMetadata({
-  title = "Seo Checkup",
-  description = "Check your websites Sitemap and MetaData here",
+  title = "SeoCheckup — Free Site Audit & SEO Tools",
+  description =
+    "Free website SEO audit, Domain Rating checker, XML sitemap expander, meta tags preview, and robots.txt viewer.",
   canonical = "/",
   ogImage = "/og-light.png",
 }: {
@@ -45,12 +46,14 @@ export function constructMetadata({
     title,
     description,
     keywords: [
-      "sitemap",
-      "metadata",
+      "seo audit",
+      "site audit",
+      "domain rating",
+      "domain rating checker",
       "sitemap checker",
-      "metatag checker",
-      "sitemap generator",
-      "metatag generator",
+      "xml sitemap",
+      "meta tags checker",
+      "robots.txt checker",
       "seo checkup",
     ],
     openGraph: {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -33,7 +33,7 @@ export function getSitemapBaseUrl(sitemapUrl: string): string {
 export function constructMetadata({
   title = "SeoCheckup — Free Site Audit & SEO Tools",
   description =
-    "Free website SEO audit, Domain Rating checker, XML sitemap expander, meta tags preview, and robots.txt viewer.",
+    "Free site audit for any website — check sitemap, meta tags, robots.txt, and Domain Rating in one go.",
   canonical = "/",
   ogImage = "/og-light.png",
 }: {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,6 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
+import { SITE_URL } from "@/lib/site"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -41,8 +42,10 @@ export function constructMetadata({
   canonical: string
   ogImage?: string
 }) {
+  const path = canonical.startsWith("/") ? canonical : `/${canonical}`
+
   return {
-    metadataBase: new URL("https://seocheckup.vercel.app"),
+    metadataBase: new URL(SITE_URL),
     title,
     description,
     keywords: [
@@ -60,13 +63,13 @@ export function constructMetadata({
       title,
       description,
       type: "website",
-      url: canonical,
+      url: path,
       images: [
         {
           url: ogImage,
           width: 1200,
           height: 630,
-          alt: "OG Image",
+          alt: title,
         },
       ],
     },
@@ -74,7 +77,7 @@ export function constructMetadata({
       icon: "/icon.png",
     },
     alternates: {
-      canonical,
+      canonical: path,
     },
     authors: [
       {
@@ -89,6 +92,7 @@ export function constructMetadata({
       creator: "@shribuilds",
       site: "shri",
       card: "summary_large_image",
+      images: [ogImage],
     },
   }
 }

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,0 +1,65 @@
+import type { MDXComponents } from "mdx/types"
+import Link from "next/link"
+
+export function useMDXComponents(components: MDXComponents): MDXComponents {
+  return {
+    h1: (props) => (
+      <h1
+        className="text-3xl sm:text-4xl font-bold tracking-tight font-mono mt-0 mb-6"
+        {...props}
+      />
+    ),
+    h2: (props) => (
+      <h2
+        className="text-xl sm:text-2xl font-semibold tracking-tight mt-10 mb-3"
+        {...props}
+      />
+    ),
+    h3: (props) => (
+      <h3 className="text-lg font-semibold mt-8 mb-2" {...props} />
+    ),
+    p: (props) => (
+      <p className="text-muted-foreground leading-relaxed mb-4" {...props} />
+    ),
+    ul: (props) => (
+      <ul className="list-disc pl-5 space-y-2 mb-4 text-muted-foreground" {...props} />
+    ),
+    ol: (props) => (
+      <ol className="list-decimal pl-5 space-y-2 mb-4 text-muted-foreground" {...props} />
+    ),
+    li: (props) => <li className="leading-relaxed" {...props} />,
+    a: ({ href, ...props }) => {
+      if (href?.startsWith("/")) {
+        return (
+          <Link
+            href={href}
+            className="underline underline-offset-2 text-foreground"
+            {...props}
+          />
+        )
+      }
+      return (
+        <a
+          href={href}
+          className="underline underline-offset-2 text-foreground"
+          target="_blank"
+          rel="noopener noreferrer"
+          {...props}
+        />
+      )
+    },
+    blockquote: (props) => (
+      <blockquote
+        className="border-l-2 border-foreground/30 pl-4 italic text-muted-foreground my-6"
+        {...props}
+      />
+    ),
+    code: (props) => (
+      <code
+        className="font-mono text-sm bg-muted px-1.5 py-0.5 rounded"
+        {...props}
+      />
+    ),
+    ...components,
+  }
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,5 @@
+import createMDX from "@next/mdx"
+
 /** @type {import('next').NextConfig} */
 
 const url =
@@ -6,6 +8,7 @@ const url =
     : "https://seocheckup.vercel.app"
 
 const nextConfig = {
+  pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
   images: {
     remotePatterns: [
       {
@@ -35,4 +38,9 @@ const nextConfig = {
     ]
   },
 }
-export default nextConfig
+
+const withMDX = createMDX({
+  extension: /\.mdx?$/,
+})
+
+export default withMDX(nextConfig)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint ."
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.0.6",
@@ -17,23 +17,24 @@
     "@upstash/redis": "^1.34.5",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
-    "framer-motion": "^11.0.3",
+    "framer-motion": "^12.42.2",
     "geist": "^1.2.1",
     "lucide-react": "^0.321.0",
-    "next": "14.2.35",
+    "next": "16.2.10",
     "next-themes": "^0.2.1",
-    "react": "^18",
-    "react-dom": "^18",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.6",
     "@types/node": "^20",
-    "@types/react": "^18",
-    "@types/react-dom": "^18",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
     "autoprefixer": "^10.0.1",
-    "eslint": "^8",
-    "eslint-config-next": "14.1.0",
+    "eslint": "^9.39.5",
+    "eslint-config-next": "16.2.10",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
     "typescript": "^5"

--- a/package.json
+++ b/package.json
@@ -10,10 +10,14 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@mdx-js/loader": "^3.1.1",
+    "@mdx-js/react": "^3.1.1",
+    "@next/mdx": "^16.2.10",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-navigation-menu": "^1.1.4",
     "@radix-ui/react-slot": "^1.0.2",
+    "@tailwindcss/typography": "^0.5.20",
     "@upstash/ratelimit": "^2.0.5",
     "@upstash/redis": "^1.34.5",
     "class-variance-authority": "^0.7.0",
@@ -30,6 +34,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.6",
+    "@types/mdx": "^2.0.14",
     "@types/node": "^20",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "seo-checkup",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/plans/001-nextjs-16-upgrade.md
+++ b/plans/001-nextjs-16-upgrade.md
@@ -1,0 +1,84 @@
+# 001 — Next.js 14 → 16 upgrade
+
+**Commit stamped:** `f80b491`  
+**Category:** dependencies & migrations  
+**Effort:** M  
+**Status:** PENDING
+
+## Why
+
+App is on **Next.js `14.2.35`** + **React 18**. Latest stable is **Next.js 16.2.x** with **React 19**. v16 fully removes sync `searchParams`/`params` (already breaking for this app’s tool pages). `eslint-config-next` is skewed at `14.1.0`.
+
+## Package manager
+
+Already **pnpm**. Use only `pnpm` / `pnpm dlx` commands. Do **not** add yarn or npm lockfiles.
+
+## Current state (excerpts)
+
+`package.json`:
+
+```json
+"next": "14.2.35",
+"react": "^18",
+"react-dom": "^18",
+"eslint-config-next": "14.1.0"
+```
+
+Sync `searchParams` (must become async):
+
+- [`app/(tools)/sitemap/page.tsx`](../app/(tools)/sitemap/page.tsx) — `{ searchParams: { q: string } }`
+- [`app/(tools)/metadata/page.tsx`](../app/(tools)/metadata/page.tsx) — same pattern
+
+No `middleware.ts`. No custom webpack in [`next.config.mjs`](../next.config.mjs). Turbopack-default in v16 should be fine.
+
+## Steps
+
+1. Ensure Node ≥ **20.9** (local has Node 26 — OK).
+2. Run the official upgrade codemod:
+   ```bash
+   pnpm dlx @next/codemod@canary upgrade latest
+   ```
+   Accept updates for Next, React, React DOM, eslint-config-next, types.
+3. If codemod incomplete, manually:
+   ```bash
+   pnpm add next@latest react@latest react-dom@latest
+   pnpm add -D eslint-config-next@latest @types/react@latest @types/react-dom@latest typescript@latest
+   ```
+4. Convert both tool pages to async pages:
+   ```tsx
+   export default async function Sitemap({
+     searchParams,
+   }: {
+     searchParams: Promise<{ q?: string }>
+   }) {
+     const { q } = await searchParams
+     const query = q ? decodeURIComponent(q) : ""
+     return (/* ... */ <InputField query={query} />)
+   }
+   ```
+   Same for metadata page. Guard missing `q` (empty string) so decode does not throw.
+5. Align lint for Next 16: if `next lint` was removed/migrated by codemod, update `package.json` `"lint"` script to the ESLint CLI the codemod writes (do not invent a parallel lint setup).
+6. Bump `framer-motion` to a React-19-compatible release if peer deps warn (`pnpm add framer-motion@latest`).
+7. Clean `tailwind.config.ts` content globs: remove nonexistent `./pages/**/*` and `./src/**/*` if still present.
+8. Add `"packageManager": "pnpm@<installed-major>"` only if missing and easy to detect via `pnpm -v` — optional hygiene, not required for build.
+
+## Out of scope
+
+- UI redesign (003)
+- New tools (004)
+- API rate-limit HTTP status fix (004/005 — can land in 004)
+- Cache Components / PPR migration (not required for this app)
+
+## Done when
+
+```bash
+pnpm build   # exits 0
+pnpm lint    # exits 0
+```
+
+`package.json` shows `next` ≥ 16.2 and `react` ≥ 19. Tool pages use `await searchParams`. No `yarn.lock` / `package-lock.json` introduced.
+
+## Escape hatches
+
+- If Turbopack build fails on a plugin webpack inject: try `next build --webpack` once to isolate; prefer fixing Turbopack issue over permanent webpack opt-out.
+- If a peer-dep conflict blocks install: report exact conflict; do not `--force` silently without noting it in the PR notes.

--- a/plans/002-fix-sitemap-seo.md
+++ b/plans/002-fix-sitemap-seo.md
@@ -1,0 +1,37 @@
+# 002 — Fix product sitemap + SEO routes
+
+**Commit stamped:** `f80b491`  
+**Depends on:** 001 (or at least a compiling tree)  
+**Status:** PENDING
+
+## Why
+
+[`app/sitemap.ts`](../app/sitemap.ts) has a broken path: `"metadata"` lacks a leading `/`, producing `https://seocheckup.vercel.appmetadata`. Product SEO is wrong today.
+
+## Current state
+
+```ts
+const pages = ["/", "/sitemap", "metadata"]
+```
+
+[`app/robots.ts`](../app/robots.ts) points sitemap to `https://seocheckup.vercel.app/sitemap.xml` — keep in sync with new routes after 004.
+
+## Steps
+
+1. Fix pages array to absolute paths:
+   ```ts
+   const pages = ["/", "/sitemap", "/metadata"] as const
+   ```
+2. After 004 adds `/robots` tool, append `"/robots"` to the same array and set sensible `changeFrequency` / `priority` (home `1`, tools `0.8`).
+3. Ensure [`lib/utils.ts`](../lib/utils.ts) `constructMetadata` `metadataBase` / canonicals stay consistent with `https://seocheckup.vercel.app`.
+4. Manually verify generated route mentally: each URL must be `baseUrl + path` with a single slash join (use `new URL(page, baseUrl).toString()` if joining is error-prone).
+
+## Done when
+
+- No path without leading `/` in the sitemap pages list.
+- `pnpm build` still passes.
+- Visiting `/sitemap.xml` (dev or build start) lists valid absolute URLs including `/metadata`.
+
+## Out of scope
+
+- Rewriting the Sitemap Link Checker tool UI (004).

--- a/plans/003-ui-motion-polish.md
+++ b/plans/003-ui-motion-polish.md
@@ -1,0 +1,51 @@
+# 003 — UI structure + motion system
+
+**Commit stamped:** `f80b491`  
+**Depends on:** 001  
+**Status:** PENDING  
+**Skills bar:** `/improve-animations` + existing frontend design rules (preserve shadcn New York + Geist; do not invent purple/cream/broadsheet looks)
+
+## Why
+
+Landing hero is generic (feature headline overpowers brand; brand only in nav). `framer-motion` is installed but unused. `Meteors` in [`components/tool-card.tsx`](../components/tool-card.tsx) is dead code. No motion tokens / `prefers-reduced-motion` discipline.
+
+## Design decisions (locked)
+
+1. **Keep** Tailwind + `tailwindcss-animate` for Radix; **use** `framer-motion` for page/hero/result entrances and BMC toast.
+2. **Brand-first hero** on [`app/page.tsx`](../app/page.tsx): product name `SeoCheckup` as the dominant first-viewport signal; one short supporting sentence; tool cards as the CTA group. No stats strips, no floating badges on media.
+3. **Visual atmosphere:** refine existing grid background (subtle, token-aligned) — not a flat single color; no purple-gradient AI cliché.
+4. **Ship 2–3 intentional motions:** (a) hero text fade-up, (b) tool-card stagger, (c) BMC toast enter/exit. Respect `prefers-reduced-motion: reduce` (skip or instant).
+5. **Wire or delete Meteors:** wire tastefully behind tool-card hover with reduced-motion off; else delete component + `meteor` keyframes from [`tailwind.config.ts`](../tailwind.config.ts). Prefer **wire with reduced-motion guard** to use existing inventory.
+6. Add CSS motion tokens in [`app/globals.css`](../app/globals.css):
+   ```css
+   --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+   --duration-fast: 150ms;
+   --duration-normal: 250ms;
+   ```
+   Use these in Framer `transition` configs and Tailwind where practical.
+
+## Steps
+
+1. Refactor home hero composition (brand → one line → cards). Keep one composition; cards remain interactive containers.
+2. Extract small `components/motion.tsx` helpers: `FadeIn`, `StaggerChildren` wrapping `motion` with reduced-motion check via `window.matchMedia` or Framer’s `useReducedMotion`.
+3. Animate tool cards on home; keep hover transitions CSS (interruptible, short).
+4. Animate BMC toast in [`components/buy-me-coffee.tsx`](../components/buy-me-coffee.tsx) enter/exit (no `scale(0)` — use opacity + slight translateY).
+5. Soften/align one-off colors (BMC `#FFDD00`, meteor slate) toward tokens where possible without redesigning brand yellow CTA.
+6. Tool page shells ([`app/(tools)/sitemap/page.tsx`](../app/(tools)/sitemap/page.tsx), metadata): light entrance on icon+title only; do not animate every list item on every keystroke.
+
+## Out of scope
+
+- Full design-system rewrite / new fonts (keep Geist).
+- Dark-mode-only redesign.
+- Dashboard-style home layout.
+
+## Done when
+
+- First viewport clearly branded as SeoCheckup without relying on nav alone.
+- `framer-motion` is imported and used (or removed entirely if wiring fails — prefer use).
+- `prefers-reduced-motion` honored on new motions.
+- `pnpm build` passes.
+
+## Feel-check
+
+Slow-mo hero load; toggle OS reduce-motion and confirm no janky long fades; card hover still snappy (`~150–250ms`, ease-out).

--- a/plans/004-features-sitemap-robots.md
+++ b/plans/004-features-sitemap-robots.md
@@ -1,0 +1,65 @@
+# 004 — Sitemap tool UX + Robots.txt tool + API hygiene
+
+**Commit stamped:** `f80b491`  
+**Depends on:** 001, 003  
+**Status:** PENDING
+
+## Why
+
+Sitemap checker is the core product but lacks basic operator UX (counts, copy, loading skeletons). A natural third tool is a **Robots.txt viewer**. API rate-limit responses incorrectly bury HTTP status in JSON body.
+
+## Feature set (locked — implement all)
+
+### A. Sitemap Link Checker upgrades
+
+Files: [`app/(tools)/sitemap/input-field.tsx`](../app/(tools)/sitemap/input-field.tsx), [`generate-deep-routes.tsx`](../app/(tools)/sitemap/generate-deep-routes.tsx)
+
+1. Show **URL count** and parse status after load.
+2. **Copy all URLs** button (clipboard) once results exist.
+3. Replace spinner-only wait with **Skeleton** list (existing [`components/ui/skeleton.tsx`](../components/ui/skeleton.tsx)).
+4. Stagger-fade result list once (not on every re-render) via Framer helpers from 003.
+5. Guard empty/`undefined` query (from async searchParams).
+
+### B. New tool: Robots.txt viewer
+
+1. Add route group page: `app/(tools)/robots/page.tsx` + `input-field.tsx`.
+2. Fetch via existing `GET /api/v1?q=<origin>/robots.txt` (or user-pasted robots URL).
+3. Render plain-text body in a monospace block; highlight `Sitemap:` / `Disallow:` / `Allow:` / `User-agent:` lines with simple regex spans (no heavy parser dependency).
+4. Add ToolCard on home linking to `/robots?q=https://example.com/robots.txt` (use a real demo URL consistent with other cards).
+5. Metadata via `constructMetadata`; register `/robots` in product `app/sitemap.ts` (002).
+
+### C. API hygiene
+
+File: [`app/api/v1/route.ts`](../app/api/v1/route.ts)
+
+1. Rate-limit failure must return real HTTP 429:
+   ```ts
+   return NextResponse.json({ error: "Rate limit exceeded", limit, reset, remaining }, {
+     status: 429,
+     headers: {
+       "X-RateLimit-Limit": String(limit),
+       "X-RateLimit-Reset": String(reset),
+       "X-RateLimit-Remaining": String(remaining),
+     },
+   })
+   ```
+2. Same pattern for 4xx/5xx fetch failures (status on `NextResponse`, not only body).
+3. Prefer `new URL(req.url).searchParams.get("q")` over `split("q=")[1]`.
+4. **Do not** move Discord secrets in this plan unless review flags them as blocking; note `NEXT_PUBLIC_` Discord usage for 005 security review.
+
+### D. Nav / footer
+
+Update [`components/navbar.tsx`](../components/navbar.tsx) (and footer links if tools are listed) to include Robots tool.
+
+## Out of scope
+
+- Full HTTP status crawler for every sitemap URL (too heavy for rate limits).
+- Auth / paid tiers.
+
+## Done when
+
+- Three tools on home: Sitemap, Metadata, Robots.
+- Sitemap tool has count + copy + skeletons.
+- API returns proper status codes.
+- Product `sitemap.ts` includes `/robots`.
+- `pnpm build` && `pnpm lint` pass.

--- a/plans/005-review-fix-loop.md
+++ b/plans/005-review-fix-loop.md
@@ -1,0 +1,79 @@
+# 005 — Review → fix loop until green
+
+**Commit stamped:** `f80b491`  
+**Depends on:** 001–004 implemented on a feature branch  
+**Status:** PENDING
+
+## Goal
+
+Close the loop the user requested: **code → multi-agent review → fix → re-review** until build passes and reviews are clean enough to ship.
+
+## Loop (repeat until exit criteria)
+
+```mermaid
+flowchart TD
+  implement[Implement 001-004]
+  build[pnpm build and lint]
+  bugbot[Bugbot review on branch diff]
+  security[Security Review on branch diff]
+  fix[Fix blocking findings]
+  done[Done: green build + reviews]
+  implement --> build
+  build -->|fail| fix
+  build -->|pass| bugbot
+  bugbot --> security
+  bugbot -->|blocking issues| fix
+  security -->|blocking issues| fix
+  security -->|pass| done
+  fix --> build
+```
+
+### Step 1 — Verification gate
+
+```bash
+pnpm install
+pnpm build
+pnpm lint
+```
+
+Fix compile/lint failures before any review dispatch.
+
+### Step 2 — Manual smoke (implementer)
+
+- `/` — brand hero, 3 tool cards, theme toggle, reduced-motion sanity
+- `/sitemap?q=…` — load, count, copy, tree
+- `/metadata?q=…` — title/description/og preview
+- `/robots?q=…` — robots text render
+- Rate limit path optional (do not burn production Redis unnecessarily)
+
+### Step 3 — Bugbot review
+
+Dispatch Bugbot (readonly) on **branch changes** with change description summarizing 001–004. Collect blocking bugs only for the fix queue; polish nits can be batched if cheap.
+
+### Step 4 — Security review
+
+Dispatch Security Review (readonly) on **branch changes**. Prioritize:
+
+- SSRF / open proxy via `/api/v1` (URL allow/deny considerations — document residual risk if intentional product behavior)
+- `NEXT_PUBLIC_` Discord credentials in [`lib/discord-webhook.ts`](../lib/discord-webhook.ts)
+- Rate-limit bypass / header spoofing (`x-forwarded-for`)
+- XSS from rendering fetched HTML/XML/robots text (ensure text not `dangerouslySetInnerHTML` unless sanitized)
+
+Implement fixes for HIGH/MEDIUM blockers; LOW can be noted in plan index as follow-ups.
+
+### Step 5 — Fix and re-run
+
+Any blocking finding → patch → back to Step 1. Cap at **3 full loops** unless user extends; if still blocked, stop with a clear residual-risk report.
+
+## Exit criteria
+
+- `pnpm build` and `pnpm lint` exit 0
+- Bugbot: no unresolved blocking issues from the latest pass
+- Security: no unresolved HIGH issues; MEDIUM either fixed or explicitly accepted in `plans/README.md`
+- No `yarn.lock` / `package-lock.json`
+- Product sitemap URLs all valid absolute paths
+
+## Out of scope
+
+- Pushing/merging without user request
+- Full new test framework (optional tiny smoke script only if needed for a review finding)

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,48 @@
+# SEO Checkup — Execution Plans
+
+**Written against:** `f80b491`  
+**Target:** Next.js `16.2.x` (stable `@latest`), React 19, pnpm (already in use)  
+**Status:** DONE — build/lint green; Bugbot clean; Security no HIGH (SSRF accepted)
+
+## Accepted residual risks
+
+| Risk | Decision |
+| --- | --- |
+| Open proxy / SSRF via `GET /api/v1` | **Accepted product behavior** (SEO fetch tools). Mitigations added: http(s)-only, 15s timeout, ~2MB body cap, rate limit. No private-IP block yet. |
+| Legacy `NEXT_PUBLIC_DISCORD_*` env names | Server still accepts as fallback; migrate Vercel env to `DISCORD_LOGS_ID` / `DISCORD_LOGS_TOKEN` and remove public vars. Client no longer embeds webhook. |
+
+## Package manager
+
+| Check | Result |
+| --- | --- |
+| Lockfile | `pnpm-lock.yaml` present |
+| `yarn.lock` | Absent |
+| `package-lock.json` | Absent |
+| README | Documents `pnpm install` / `pnpm run dev` |
+| Verdict | **Already on pnpm — no Yarn→pnpm migration** |
+
+## Recommended order
+
+| # | Plan | Depends on | Status |
+| --- | --- | --- | --- |
+| 001 | [Next.js 14 → 16 upgrade](001-nextjs-16-upgrade.md) | — | DONE |
+| 002 | [Fix product sitemap + SEO routes](002-fix-sitemap-seo.md) | 001 (build green) | DONE |
+| 003 | [UI structure + motion system](003-ui-motion-polish.md) | 001 | DONE |
+| 004 | [Sitemap tool UX + new Robots tool](004-features-sitemap-robots.md) | 001, 003 | DONE |
+| 005 | [Review loop: build → Bugbot → Security → fix](005-review-fix-loop.md) | 001–004 | DONE |
+
+## Verification gates (every plan)
+
+```bash
+pnpm install
+pnpm build
+pnpm lint
+```
+
+No automated test suite exists today; build + lint are the hard gates. Manual smoke: `/`, `/sitemap`, `/metadata`, `/robots` (after 004), theme toggle, API `GET /api/v1?q=…`.
+
+## Execution model (multi-agent)
+
+1. **Implementer** executes 001 → 004 in order (or parallelize 002+003 after 001).
+2. **Reviewer loop (005):** Bugbot + Security Review on branch diff; any FAIL → implementer fixes → re-review until both PASS and `pnpm build` succeeds.
+3. Do not merge/push unless the user asks.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@mdx-js/loader':
+        specifier: ^3.1.1
+        version: 3.1.1
+      '@mdx-js/react':
+        specifier: ^3.1.1
+        version: 3.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@next/mdx':
+        specifier: ^16.2.10
+        version: 16.2.10(@mdx-js/loader@3.1.1)(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.0.6
         version: 2.0.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -20,6 +29,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.0.2
         version: 1.0.2(@types/react@19.2.17)(react@19.2.7)
+      '@tailwindcss/typography':
+        specifier: ^0.5.20
+        version: 0.5.20(tailwindcss@3.4.1)
       '@upstash/ratelimit':
         specifier: ^2.0.5
         version: 2.0.5(@upstash/redis@1.34.5)
@@ -63,6 +75,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3.3.6
         version: 3.3.6
+      '@types/mdx':
+        specifier: ^2.0.14
+        version: 2.0.14
       '@types/node':
         specifier: ^20
         version: 20.11.16
@@ -284,105 +299,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -441,11 +440,39 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@mdx-js/loader@3.1.1':
+    resolution: {integrity: sha512-0TTacJyZ9mDmY+VefuthVshaNIyCGZHJG2fMnGaDttCt8HmjUF7SizlHJpaCDoGnN635nK1wpzfpx/Xx5S4WnQ==}
+    peerDependencies:
+      webpack: '>=5'
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+
+  '@mdx-js/mdx@3.1.1':
+    resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
+
   '@next/env@16.2.10':
     resolution: {integrity: sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==}
 
   '@next/eslint-plugin-next@16.2.10':
     resolution: {integrity: sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==}
+
+  '@next/mdx@16.2.10':
+    resolution: {integrity: sha512-r6T32AyQ0xy6p0vKd1lNbz6RUXuVXdGYSAI0dRrpbnqGnTWQXefADZGui4PlwjqROj0XQBMqVwot9ntPWao9PA==}
+    peerDependencies:
+      '@mdx-js/loader': '>=0.15.0'
+      '@mdx-js/react': '>=0.15.0'
+    peerDependenciesMeta:
+      '@mdx-js/loader':
+        optional: true
+      '@mdx-js/react':
+        optional: true
 
   '@next/swc-darwin-arm64@16.2.10':
     resolution: {integrity: sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==}
@@ -464,28 +491,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.10':
     resolution: {integrity: sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.10':
     resolution: {integrity: sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.10':
     resolution: {integrity: sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.10':
     resolution: {integrity: sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==}
@@ -818,14 +841,37 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
+  '@tailwindcss/typography@0.5.20':
+    resolution: {integrity: sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || >=4.0.0 || insiders'
+
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdx@2.0.14':
+    resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@20.11.16':
     resolution: {integrity: sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==}
@@ -837,6 +883,12 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@typescript-eslint/eslint-plugin@8.64.0':
     resolution: {integrity: sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==}
@@ -896,6 +948,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.64.0':
     resolution: {integrity: sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
   '@upstash/core-analytics@0.0.10':
     resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
@@ -1013,6 +1068,10 @@ packages:
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
+
   autoprefixer@10.4.17:
     resolution: {integrity: sha512-/cpVNRLSfhOtcGflT13P2794gVSgmPgTR+erw5ifnMLZb0UnSlkK4tquLmkd3BhA+nLo5tX8Cu0upUsGKvKbmg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1035,6 +1094,9 @@ packages:
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1105,9 +1167,24 @@ packages:
   caniuse-lite@1.0.30001805:
     resolution: {integrity: sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -1127,12 +1204,18 @@ packages:
     resolution: {integrity: sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==}
     engines: {node: '>=6'}
 
+  collapse-white-space@2.1.0:
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1204,6 +1287,9 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1219,12 +1305,19 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -1309,6 +1402,12 @@ packages:
   es-to-primitive@1.3.4:
     resolution: {integrity: sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==}
     engines: {node: '>= 0.4'}
+
+  esast-util-from-estree@2.0.0:
+    resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
+
+  esast-util-from-js@2.0.1:
+    resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
   escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -1453,9 +1552,33 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-attach-comments@3.0.0:
+    resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
+
+  estree-util-build-jsx@3.0.1:
+    resolution: {integrity: sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-util-scope@1.0.0:
+    resolution: {integrity: sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==}
+
+  estree-util-to-js@2.0.0:
+    resolution: {integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==}
+
+  estree-util-visit@2.0.0:
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1668,6 +1791,15 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-estree@3.1.3:
+    resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
@@ -1690,6 +1822,9 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   internal-slot@1.0.6:
     resolution: {integrity: sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==}
     engines: {node: '>= 0.4'}
@@ -1700,6 +1835,12 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-array-buffer@3.0.4:
     resolution: {integrity: sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==}
@@ -1755,6 +1896,9 @@ packages:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-document.all@1.0.0:
     resolution: {integrity: sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==}
     engines: {node: '>= 0.4'}
@@ -1779,6 +1923,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
@@ -1802,6 +1949,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
@@ -1945,6 +2096,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -1961,13 +2115,128 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
 
+  markdown-extensions@2.0.0:
+    resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
+    engines: {node: '>=16'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-mdx-expression@3.0.1:
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
+
+  micromark-extension-mdx-jsx@3.0.2:
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
+
+  micromark-extension-mdx-md@2.0.0:
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
+
+  micromark-extension-mdxjs@3.0.0:
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-mdx-expression@2.0.3:
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-events-to-acorn@2.0.3:
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
@@ -2124,6 +2393,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2195,6 +2467,10 @@ packages:
     peerDependencies:
       postcss: ^8.2.14
 
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+
   postcss-selector-parser@6.0.15:
     resolution: {integrity: sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==}
     engines: {node: '>=4'}
@@ -2216,6 +2492,9 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2273,6 +2552,20 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  recma-build-jsx@1.0.0:
+    resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
+
+  recma-jsx@1.0.1:
+    resolution: {integrity: sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  recma-parse@1.0.0:
+    resolution: {integrity: sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==}
+
+  recma-stringify@1.0.0:
+    resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -2287,6 +2580,18 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  rehype-recma@1.0.0:
+    resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  remark-mdx@3.1.1:
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2401,6 +2706,13 @@ packages:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -2446,6 +2758,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -2461,6 +2776,12 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -2519,6 +2840,12 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -2595,6 +2922,27 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position-from-estree@2.0.0:
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   update-browserslist-db@1.0.13:
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
     hasBin: true
@@ -2632,6 +2980,12 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
@@ -2688,6 +3042,9 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -3031,11 +3388,61 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
+  '@mdx-js/loader@3.1.1':
+    dependencies:
+      '@mdx-js/mdx': 3.1.1
+      source-map: 0.7.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@mdx-js/mdx@3.1.1':
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdx': 2.0.14
+      acorn: 8.17.0
+      collapse-white-space: 2.1.0
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-util-scope: 1.0.0
+      estree-walker: 3.0.3
+      hast-util-to-jsx-runtime: 2.3.6
+      markdown-extensions: 2.0.0
+      recma-build-jsx: 1.0.0
+      recma-jsx: 1.0.1(acorn@8.17.0)
+      recma-stringify: 1.0.0
+      rehype-recma: 1.0.0
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      source-map: 0.7.6
+      unified: 11.0.5
+      unist-util-position-from-estree: 2.0.0
+      unist-util-stringify-position: 4.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@types/mdx': 2.0.14
+      '@types/react': 19.2.17
+      react: 19.2.7
+
   '@next/env@16.2.10': {}
 
   '@next/eslint-plugin-next@16.2.10':
     dependencies:
       fast-glob: 3.3.1
+
+  '@next/mdx@16.2.10(@mdx-js/loader@3.1.1)(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))':
+    dependencies:
+      source-map: 0.7.6
+    optionalDependencies:
+      '@mdx-js/loader': 3.1.1
+      '@mdx-js/react': 3.1.1(@types/react@19.2.17)(react@19.2.7)
 
   '@next/swc-darwin-arm64@16.2.10':
     optional: true
@@ -3384,11 +3791,36 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@tailwindcss/typography@0.5.20(tailwindcss@3.4.1)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 3.4.1
+
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
+
   '@types/estree@1.0.9': {}
+
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdx@2.0.14': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@20.11.16':
     dependencies:
@@ -3401,6 +3833,10 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)':
     dependencies:
@@ -3492,6 +3928,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.64.0
       eslint-visitor-keys: 5.0.1
+
+  '@ungap/structured-clone@1.3.3': {}
 
   '@upstash/core-analytics@0.0.10':
     dependencies:
@@ -3652,6 +4090,8 @@ snapshots:
 
   ast-types-flow@0.0.8: {}
 
+  astring@1.9.0: {}
+
   autoprefixer@10.4.17(postcss@8.4.33):
     dependencies:
       browserslist: 4.22.3
@@ -3671,6 +4111,8 @@ snapshots:
   axe-core@4.12.1: {}
 
   axobject-query@4.1.0: {}
+
+  bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
 
@@ -3743,10 +4185,20 @@ snapshots:
 
   caniuse-lite@1.0.30001805: {}
 
+  ccount@2.0.1: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chokidar@3.5.3:
     dependencies:
@@ -3770,11 +4222,15 @@ snapshots:
 
   clsx@2.1.0: {}
 
+  collapse-white-space@2.1.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@4.1.1: {}
 
@@ -3832,6 +4288,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.1:
@@ -3852,10 +4312,16 @@ snapshots:
       has-property-descriptors: 1.0.1
       object-keys: 1.1.1
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2:
     optional: true
 
   detect-node-es@1.1.0: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   didyoumean@1.2.2: {}
 
@@ -4055,6 +4521,20 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  esast-util-from-estree@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      unist-util-position-from-estree: 2.0.0
+
+  esast-util-from-js@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      acorn: 8.17.0
+      esast-util-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
   escalade@3.1.1: {}
 
   escalade@3.2.0: {}
@@ -4066,7 +4546,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.10
       eslint: 9.39.5(jiti@1.21.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@1.21.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.5(jiti@1.21.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@1.21.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@1.21.0))
@@ -4088,12 +4568,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0)):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@1.21.0)):
     dependencies:
       debug: 4.4.3
       enhanced-resolve: 5.15.0
       eslint: 9.39.5(jiti@1.21.0)
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0))
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.5(jiti@1.21.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.5(jiti@1.21.0))
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
@@ -4105,25 +4585,25 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.5(jiti@1.21.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)
       eslint: 9.39.5(jiti@1.21.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@1.21.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0)):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.5(jiti@1.21.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)
       eslint: 9.39.5(jiti@1.21.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@1.21.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -4138,7 +4618,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@1.21.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.5(jiti@1.21.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -4276,7 +4756,42 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-attach-comments@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  estree-util-build-jsx@3.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-walker: 3.0.3
+
+  estree-util-is-identifier-name@3.0.0: {}
+
+  estree-util-scope@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+
+  estree-util-to-js@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      astring: 1.9.0
+      source-map: 0.7.6
+
+  estree-util-visit@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
+
+  extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -4498,6 +5013,51 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-estree@3.1.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-attach-comments: 3.0.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      zwitch: 2.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
@@ -4515,6 +5075,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inline-style-parser@0.2.7: {}
+
   internal-slot@1.0.6:
     dependencies:
       get-intrinsic: 1.2.2
@@ -4530,6 +5092,13 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-array-buffer@3.0.4:
     dependencies:
@@ -4593,6 +5162,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-decimal@2.0.1: {}
+
   is-document.all@1.0.0:
     dependencies:
       call-bound: 1.0.4
@@ -4613,6 +5184,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.2: {}
@@ -4629,6 +5202,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-regex@1.1.4:
     dependencies:
@@ -4769,6 +5344,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -4783,9 +5360,316 @@ snapshots:
     dependencies:
       react: 19.2.7
 
+  markdown-extensions@2.0.0: {}
+
   math-intrinsics@1.1.0: {}
 
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx@3.0.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-expression@3.0.1:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-jsx@3.0.2:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-extension-mdx-md@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-extension-mdxjs@3.0.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      micromark-extension-mdx-expression: 3.0.1
+      micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdx-md: 2.0.0
+      micromark-extension-mdxjs-esm: 3.0.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-mdx-expression@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-events-to-acorn@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.5:
     dependencies:
@@ -4952,6 +5836,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -5001,6 +5895,11 @@ snapshots:
       postcss: 8.4.33
       postcss-selector-parser: 6.0.15
 
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss-selector-parser@6.0.15:
     dependencies:
       cssesc: 3.0.0
@@ -5027,6 +5926,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  property-information@7.2.0: {}
 
   punycode@2.3.1: {}
 
@@ -5077,6 +5978,35 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  recma-build-jsx@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-util-build-jsx: 3.0.1
+      vfile: 6.0.3
+
+  recma-jsx@1.0.1(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      estree-util-to-js: 2.0.0
+      recma-parse: 1.0.0
+      recma-stringify: 1.0.0
+      unified: 11.0.5
+
+  recma-parse@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      esast-util-from-js: 2.0.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  recma-stringify@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-util-to-js: 2.0.0
+      unified: 11.0.5
+      vfile: 6.0.3
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.9
@@ -5104,6 +6034,38 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  rehype-recma@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.5
+      hast-util-to-estree: 3.1.3
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-mdx@3.1.1:
+    dependencies:
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
 
   resolve-from@4.0.0: {}
 
@@ -5277,6 +6239,10 @@ snapshots:
 
   source-map-js@1.0.2: {}
 
+  source-map@0.7.6: {}
+
+  space-separated-tokens@2.0.2: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -5363,6 +6329,11 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -5374,6 +6345,14 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
     dependencies:
@@ -5451,6 +6430,10 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
 
   ts-api-utils@2.5.0(typescript@5.3.3):
     dependencies:
@@ -5562,6 +6545,43 @@ snapshots:
 
   undici-types@5.26.5: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position-from-estree@2.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   update-browserslist-db@1.0.13(browserslist@4.22.3):
     dependencies:
       browserslist: 4.22.3
@@ -5594,6 +6614,16 @@ snapshots:
       '@types/react': 19.2.17
 
   util-deprecate@1.0.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   which-boxed-primitive@1.0.2:
     dependencies:
@@ -5679,3 +6709,5 @@ snapshots:
       zod: 4.4.3
 
   zod@4.4.3: {}
+
+  zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,16 +10,16 @@ importers:
     dependencies:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.0.6
-        version: 2.0.6(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 2.0.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-icons':
         specifier: ^1.3.0
-        version: 1.3.0(react@18.2.0)
+        version: 1.3.0(react@19.2.7)
       '@radix-ui/react-navigation-menu':
         specifier: ^1.1.4
-        version: 1.1.4(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 1.1.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-slot':
         specifier: ^1.0.2
-        version: 1.0.2(@types/react@18.2.52)(react@18.2.0)
+        version: 1.0.2(@types/react@19.2.17)(react@19.2.7)
       '@upstash/ratelimit':
         specifier: ^2.0.5
         version: 2.0.5(@upstash/redis@1.34.5)
@@ -33,26 +33,26 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       framer-motion:
-        specifier: ^11.0.3
-        version: 11.0.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: ^12.42.2
+        version: 12.42.2(@emotion/is-prop-valid@0.8.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       geist:
         specifier: ^1.2.1
-        version: 1.2.1(next@14.2.35(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 1.2.1(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       lucide-react:
         specifier: ^0.321.0
-        version: 0.321.0(react@18.2.0)
+        version: 0.321.0(react@19.2.7)
       next:
-        specifier: 14.2.35
-        version: 14.2.35(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 16.2.10
+        version: 16.2.10(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@14.2.35(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.2.1(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
-        specifier: ^18
-        version: 18.2.0
+        specifier: ^19.2.7
+        version: 19.2.7
       react-dom:
-        specifier: ^18
-        version: 18.2.0(react@18.2.0)
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
       tailwind-merge:
         specifier: ^2.2.1
         version: 2.2.1
@@ -60,24 +60,27 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.1)
     devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3.3.6
+        version: 3.3.6
       '@types/node':
         specifier: ^20
         version: 20.11.16
       '@types/react':
-        specifier: ^18
-        version: 18.2.52
+        specifier: ^19.2.17
+        version: 19.2.17
       '@types/react-dom':
-        specifier: ^18
-        version: 18.2.18
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
       autoprefixer:
         specifier: ^10.0.1
         version: 10.4.17(postcss@8.4.33)
       eslint:
-        specifier: ^8
-        version: 8.56.0
+        specifier: ^9.39.5
+        version: 9.39.5(jiti@1.21.0)
       eslint-config-next:
-        specifier: 14.1.0
-        version: 14.1.0(eslint@8.56.0)(typescript@5.3.3)
+        specifier: 16.2.10
+        version: 16.2.10(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)
       postcss:
         specifier: ^8
         version: 8.4.33
@@ -98,9 +101,79 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.23.9':
     resolution: {integrity: sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
   '@emotion/is-prop-valid@0.8.8':
     resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
@@ -108,23 +181,43 @@ packages:
   '@emotion/memoize@0.7.4':
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
 
-  '@eslint-community/eslint-utils@4.4.0':
-    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
-  '@eslint-community/regexpp@4.10.0':
-    resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/eslintrc@2.1.4':
-    resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@8.56.0':
-    resolution: {integrity: sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.6':
+    resolution: {integrity: sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.5':
+    resolution: {integrity: sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@floating-ui/core@1.6.0':
     resolution: {integrity: sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==}
@@ -141,26 +234,192 @@ packages:
   '@floating-ui/utils@0.2.1':
     resolution: {integrity: sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==}
 
-  '@humanwhocodes/config-array@0.11.14':
-    resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
-    engines: {node: '>=10.10.0'}
-    deprecated: Use @eslint/config-array instead
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
 
-  '@humanwhocodes/object-schema@2.0.2':
-    resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
-    deprecated: Use @eslint/object-schema instead
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
   '@jridgewell/gen-mapping@0.3.3':
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
     engines: {node: '>=6.0.0'}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.1':
     resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
@@ -173,65 +432,69 @@ packages:
   '@jridgewell/sourcemap-codec@1.4.15':
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@jridgewell/trace-mapping@0.3.22':
     resolution: {integrity: sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==}
 
-  '@next/env@14.2.35':
-    resolution: {integrity: sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==}
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@next/eslint-plugin-next@14.1.0':
-    resolution: {integrity: sha512-x4FavbNEeXx/baD/zC/SdrvkjSby8nBn8KcCREqk6UuwvwoAPZmaV8TFCAuo/cpovBRTIY67mHhe86MQQm/68Q==}
+  '@next/env@16.2.10':
+    resolution: {integrity: sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==}
 
-  '@next/swc-darwin-arm64@14.2.33':
-    resolution: {integrity: sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==}
+  '@next/eslint-plugin-next@16.2.10':
+    resolution: {integrity: sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==}
+
+  '@next/swc-darwin-arm64@16.2.10':
+    resolution: {integrity: sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@14.2.33':
-    resolution: {integrity: sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==}
+  '@next/swc-darwin-x64@16.2.10':
+    resolution: {integrity: sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@14.2.33':
-    resolution: {integrity: sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==}
+  '@next/swc-linux-arm64-gnu@16.2.10':
+    resolution: {integrity: sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@14.2.33':
-    resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
+  '@next/swc-linux-arm64-musl@16.2.10':
+    resolution: {integrity: sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@next/swc-linux-x64-gnu@14.2.33':
-    resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
+  '@next/swc-linux-x64-gnu@16.2.10':
+    resolution: {integrity: sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@next/swc-linux-x64-musl@14.2.33':
-    resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
+  '@next/swc-linux-x64-musl@16.2.10':
+    resolution: {integrity: sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@14.2.33':
-    resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
+  '@next/swc-win32-arm64-msvc@16.2.10':
+    resolution: {integrity: sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-ia32-msvc@14.2.33':
-    resolution: {integrity: sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==}
-    engines: {node: '>= 10'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@next/swc-win32-x64-msvc@14.2.33':
-    resolution: {integrity: sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==}
+  '@next/swc-win32-x64-msvc@16.2.10':
+    resolution: {integrity: sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -549,14 +812,17 @@ packages:
   '@radix-ui/rect@1.0.1':
     resolution: {integrity: sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==}
 
-  '@rushstack/eslint-patch@1.7.2':
-    resolution: {integrity: sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA==}
+  '@rtsao/scc@1.1.0':
+    resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
-  '@swc/counter@0.1.3':
-    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
-  '@swc/helpers@0.5.5':
-    resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
@@ -564,51 +830,72 @@ packages:
   '@types/node@20.11.16':
     resolution: {integrity: sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==}
 
-  '@types/prop-types@15.7.11':
-    resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
-
-  '@types/react-dom@18.2.18':
-    resolution: {integrity: sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==}
-
-  '@types/react@18.2.52':
-    resolution: {integrity: sha512-E/YjWh3tH+qsLKaUzgpZb5AY0ChVa+ZJzF7ogehVILrFpdQk6nC/WXOv0bfFEABbXbgNxLBGU7IIZByPKb6eBw==}
-
-  '@types/scheduler@0.16.8':
-    resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
-
-  '@typescript-eslint/parser@6.20.0':
-    resolution: {integrity: sha512-bYerPDF/H5v6V76MdMYhjwmwgMA+jlPVqjSDq2cRqMi8bP5sR3Z+RLOiOMad3nsnmDVmn2gAFCyNgh/dIrfP/w==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      '@types/react': ^19.2.0
 
-  '@typescript-eslint/scope-manager@6.20.0':
-    resolution: {integrity: sha512-p4rvHQRDTI1tGGMDFQm+GtxP1ZHyAh64WANVoyEcNMpaTFn3ox/3CcgtIlELnRfKzSs/DwYlDccJEtr3O6qBvA==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
-  '@typescript-eslint/types@6.20.0':
-    resolution: {integrity: sha512-MM9mfZMAhiN4cOEcUOEx+0HmuaW3WBfukBZPCfwSqFnQy0grXYtngKCqpQN339X3RrwtzspWJrpbrupKYUSBXQ==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-
-  '@typescript-eslint/typescript-estree@6.20.0':
-    resolution: {integrity: sha512-RnRya9q5m6YYSpBN7IzKu9FmLcYtErkDkc8/dKv81I9QiLLtVBHrjz+Ev/crAqgMNW2FCsoZF4g2QUylMnJz+g==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  '@typescript-eslint/eslint-plugin@8.64.0':
+    resolution: {integrity: sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      '@typescript-eslint/parser': ^8.64.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@6.20.0':
-    resolution: {integrity: sha512-E8Cp98kRe4gKHjJD4NExXKz/zOJ1A2hhZc+IMVD6i7w4yjIvh6VyuRI0gRtxAsXtoC35uGMaQ9rjI2zJaXDEAw==}
-    engines: {node: ^16.0.0 || >=18.0.0}
+  '@typescript-eslint/parser@8.64.0':
+    resolution: {integrity: sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
-  '@ungap/structured-clone@1.2.0':
-    resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+  '@typescript-eslint/project-service@8.64.0':
+    resolution: {integrity: sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.64.0':
+    resolution: {integrity: sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.64.0':
+    resolution: {integrity: sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.64.0':
+    resolution: {integrity: sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.64.0':
+    resolution: {integrity: sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.64.0':
+    resolution: {integrity: sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.64.0':
+    resolution: {integrity: sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.64.0':
+    resolution: {integrity: sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@upstash/core-analytics@0.0.10':
     resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
@@ -627,13 +914,13 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn@8.11.3:
-    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -668,44 +955,63 @@ packages:
     resolution: {integrity: sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==}
     engines: {node: '>=10'}
 
-  aria-query@5.3.0:
-    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   array-buffer-byte-length@1.0.0:
     resolution: {integrity: sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==}
+
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
+    engines: {node: '>= 0.4'}
 
   array-includes@3.1.7:
     resolution: {integrity: sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==}
     engines: {node: '>= 0.4'}
 
-  array-union@2.1.0:
-    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
-    engines: {node: '>=8'}
+  array-includes@3.1.9:
+    resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
+    engines: {node: '>= 0.4'}
 
-  array.prototype.findlastindex@1.2.3:
-    resolution: {integrity: sha512-LzLoiOMAxvy+Gd3BAq3B7VeIgPdo+Q8hthvKtXybMvRV0jrXfJM/t8mw7nNlpEcVlVUnCnM2KSX4XU5HmpodOA==}
+  array.prototype.findlast@1.2.5:
+    resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.findlastindex@1.2.6:
+    resolution: {integrity: sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==}
     engines: {node: '>= 0.4'}
 
   array.prototype.flat@1.3.2:
     resolution: {integrity: sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==}
     engines: {node: '>= 0.4'}
 
+  array.prototype.flat@1.3.3:
+    resolution: {integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==}
+    engines: {node: '>= 0.4'}
+
   array.prototype.flatmap@1.3.2:
     resolution: {integrity: sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==}
     engines: {node: '>= 0.4'}
 
-  array.prototype.tosorted@1.1.2:
-    resolution: {integrity: sha512-HuQCHOlk1Weat5jzStICBCd83NxiIMwqDg/dHEsoefabn/hJRj5pVdWcPUSpRrwhwxZOsQassMpgN/xRYFBMIg==}
+  array.prototype.flatmap@1.3.3:
+    resolution: {integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.tosorted@1.1.4:
+    resolution: {integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==}
+    engines: {node: '>= 0.4'}
 
   arraybuffer.prototype.slice@1.0.2:
     resolution: {integrity: sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==}
     engines: {node: '>= 0.4'}
 
+  arraybuffer.prototype.slice@1.0.4:
+    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
+    engines: {node: '>= 0.4'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
-
-  asynciterator.prototype@1.0.0:
-    resolution: {integrity: sha512-wwHYEIS0Q80f5mosx3L/dfG5t5rjEa9Ft51GTaNt862EnpyGHpgz2RkZvLPp1oF5TnAiTohkEKVEu8pQPJI7Vg==}
 
   autoprefixer@10.4.17:
     resolution: {integrity: sha512-/cpVNRLSfhOtcGflT13P2794gVSgmPgTR+erw5ifnMLZb0UnSlkK4tquLmkd3BhA+nLo5tX8Cu0upUsGKvKbmg==}
@@ -718,15 +1024,29 @@ packages:
     resolution: {integrity: sha512-j1QzY8iPNPG4o4xmO3ptzpRxTciqD3MgEHtifP/YnJpIo58Xu+ne4BejlbkuaLfXn/nz6HFiw29bLpj2PNMdGg==}
     engines: {node: '>= 0.4'}
 
-  axe-core@4.7.0:
-    resolution: {integrity: sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==}
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
     engines: {node: '>=4'}
 
-  axobject-query@3.2.1:
-    resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  baseline-browser-mapping@2.10.43:
+    resolution: {integrity: sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
   binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
@@ -738,6 +1058,10 @@ packages:
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
 
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+    engines: {node: 18 || 20 || >=22}
+
   braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
     engines: {node: '>=8'}
@@ -747,12 +1071,25 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  busboy@1.6.0:
-    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
-    engines: {node: '>=10.16.0'}
+  browserslist@4.28.6:
+    resolution: {integrity: sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   call-bind@1.0.5:
     resolution: {integrity: sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -764,6 +1101,9 @@ packages:
 
   caniuse-lite@1.0.30001583:
     resolution: {integrity: sha512-acWTYaha8xfhA/Du/z4sNZjHUWjkiuoAi2LM+T/aL+kemKQgPT1xBb/YKjlQ0Qo8gvbHsGNplrEJ+9G3gL7i4Q==}
+
+  caniuse-lite@1.0.30001805:
+    resolution: {integrity: sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -801,8 +1141,15 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
+    engines: {node: '>= 8'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
   crypto-js@4.2.0:
@@ -813,11 +1160,23 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-view-buffer@1.0.2:
+    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-length@1.0.2:
+    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-offset@1.0.1:
+    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
+    engines: {node: '>= 0.4'}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -836,6 +1195,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -843,23 +1211,23 @@ packages:
     resolution: {integrity: sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==}
     engines: {node: '>= 0.4'}
 
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
-  dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
-
-  dir-glob@3.0.1:
-    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
-    engines: {node: '>=8'}
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
@@ -868,15 +1236,18 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
-  doctrine@3.0.0:
-    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
-    engines: {node: '>=6.0.0'}
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
   electron-to-chromium@1.4.656:
     resolution: {integrity: sha512-9AQB5eFTHyR3Gvt2t/NwR0le2jBSUNwCnMbUCejFWHD+so4tH40/dRLgoE+jxlPeWS43XJewyvCv+I8LPMl49Q==}
+
+  electron-to-chromium@1.5.389:
+    resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -888,36 +1259,73 @@ packages:
     resolution: {integrity: sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==}
     engines: {node: '>=10.13.0'}
 
+  es-abstract-get@1.0.0:
+    resolution: {integrity: sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==}
+    engines: {node: '>= 0.4'}
+
   es-abstract@1.22.3:
     resolution: {integrity: sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==}
     engines: {node: '>= 0.4'}
 
-  es-iterator-helpers@1.0.15:
-    resolution: {integrity: sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==}
+  es-abstract@1.24.2:
+    resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-iterator-helpers@1.4.0:
+    resolution: {integrity: sha512-c/A0P0oxkACDc+cKWw8evLXK83oBKgn0qPOqCYT4x9uolpCIJAcYvJC9QYKNDRPsTeGyCrQ326jrvgZWdCdK5Q==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   es-set-tostringtag@2.0.2:
     resolution: {integrity: sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==}
     engines: {node: '>= 0.4'}
 
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
   es-shim-unscopables@1.0.2:
     resolution: {integrity: sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==}
 
+  es-shim-unscopables@1.1.0:
+    resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
+    engines: {node: '>= 0.4'}
+
   es-to-primitive@1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
+    engines: {node: '>= 0.4'}
+
+  es-to-primitive@1.3.4:
+    resolution: {integrity: sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==}
     engines: {node: '>= 0.4'}
 
   escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
 
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-config-next@14.1.0:
-    resolution: {integrity: sha512-SBX2ed7DoRFXC6CQSLc/SbLY9Ut6HxNB2wPTcoIWjUMd7aF7O/SIE7111L8FdZ9TXsNV4pulUDnfthpyPtbFUg==}
+  eslint-config-next@16.2.10:
+    resolution: {integrity: sha512-HSybLOY0QKf39i4FWUqPN0xWiNDi6A6UqJmZtgDkS3zMqjXTqULvj/sueXx3cdCG0mVG+qH6k5/qdegklH1d1w==}
     peerDependencies:
-      eslint: ^7.23.0 || ^8.0.0
+      eslint: '>=9.0.0'
       typescript: '>=3.3.1'
     peerDependenciesMeta:
       typescript:
@@ -932,6 +1340,27 @@ packages:
     peerDependencies:
       eslint: '*'
       eslint-plugin-import: '*'
+
+  eslint-module-utils@2.14.0:
+    resolution: {integrity: sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
 
   eslint-module-utils@2.8.0:
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
@@ -954,51 +1383,63 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
 
-  eslint-plugin-import@2.29.1:
-    resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
+  eslint-plugin-import@2.32.0:
+    resolution: {integrity: sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==}
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
 
-  eslint-plugin-jsx-a11y@6.8.0:
-    resolution: {integrity: sha512-Hdh937BS3KdwwbBaKd5+PLCOmYY6U4f2h9Z2ktwtNKvIdIEu137rjYbcb9ApSbVJfWxANNuiKTD/9tOKjK9qOA==}
+  eslint-plugin-jsx-a11y@6.10.2:
+    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
     engines: {node: '>=4.0'}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
 
-  eslint-plugin-react-hooks@4.6.0:
-    resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
-    engines: {node: '>=10'}
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
+    engines: {node: '>=18'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
 
-  eslint-plugin-react@7.33.2:
-    resolution: {integrity: sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==}
+  eslint-plugin-react@7.37.5:
+    resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
     engines: {node: '>=4'}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
-  eslint-scope@7.2.2:
-    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  eslint@8.56.0:
-    resolution: {integrity: sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
-    hasBin: true
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  espree@9.6.1:
-    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.39.5:
+    resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   esquery@1.5.0:
     resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
@@ -1019,6 +1460,10 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-glob@3.3.1:
+    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
+    engines: {node: '>=8.6.0'}
+
   fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
     engines: {node: '>=8.6.0'}
@@ -1032,9 +1477,18 @@ packages:
   fastq@1.17.0:
     resolution: {integrity: sha512-zGygtijUMT7jnk3h26kUms3BkSDp4IfIKjmnqI2tvx6nuBfiF1UqOxbnLfzdv+apBy+53oaImsKtMw/xYbW+1w==}
 
-  file-entry-cache@6.0.1:
-    resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
 
   fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
@@ -1044,15 +1498,19 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
-  flat-cache@3.2.0:
-    resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
 
   flatted@3.2.9:
     resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
 
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
+
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
 
   foreground-child@3.1.1:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
@@ -1061,19 +1519,19 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
-  framer-motion@11.0.3:
-    resolution: {integrity: sha512-6x2poQpIWBdbZwLd73w6cKZ1I9IEPIU94C6/Swp1Zt3LJ+sB5bPe1E2wC6EH5hSISXNkMJ4afH7AdwS7MrtkWw==}
+  framer-motion@12.42.2:
+    resolution: {integrity: sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==}
     peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
       react:
         optional: true
       react-dom:
         optional: true
-
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1087,6 +1545,10 @@ packages:
     resolution: {integrity: sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==}
     engines: {node: '>= 0.4'}
 
+  function.prototype.name@1.2.0:
+    resolution: {integrity: sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==}
+    engines: {node: '>= 0.4'}
+
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
@@ -1095,15 +1557,31 @@ packages:
     peerDependencies:
       next: ^13.2 || ^14
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-intrinsic@1.2.2:
     resolution: {integrity: sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
 
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
+    engines: {node: '>= 0.4'}
+
+  get-symbol-description@1.1.0:
+    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
   get-tsconfig@4.7.2:
@@ -1120,32 +1598,34 @@ packages:
   glob@10.3.10:
     resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
 
-  globals@13.24.0:
-    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
-    engines: {node: '>=8'}
+  globals@16.4.0:
+    resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
+    engines: {node: '>=18'}
 
   globalthis@1.0.3:
     resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
     engines: {node: '>= 0.4'}
 
-  globby@11.1.0:
-    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
-    engines: {node: '>=10'}
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
 
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  graphemer@1.4.0:
-    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
@@ -1157,12 +1637,23 @@ packages:
   has-property-descriptors@1.0.1:
     resolution: {integrity: sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==}
 
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
   has-proto@1.0.1:
     resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
     engines: {node: '>= 0.4'}
 
+  has-proto@1.2.0:
+    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
+    engines: {node: '>= 0.4'}
+
   has-symbols@1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
   has-tostringtag@1.0.2:
@@ -1173,8 +1664,22 @@ packages:
     resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
     engines: {node: '>= 0.4'}
 
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
   ignore@5.3.1:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
   import-fresh@3.3.0:
@@ -1185,15 +1690,12 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
-
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
   internal-slot@1.0.6:
     resolution: {integrity: sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==}
+    engines: {node: '>= 0.4'}
+
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
   invariant@2.2.4:
@@ -1203,12 +1705,20 @@ packages:
     resolution: {integrity: sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==}
     engines: {node: '>= 0.4'}
 
+  is-array-buffer@3.0.5:
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
+
   is-async-function@2.0.0:
     resolution: {integrity: sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==}
     engines: {node: '>= 0.4'}
 
   is-bigint@1.0.4:
     resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
+
+  is-bigint@1.1.0:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -1218,6 +1728,10 @@ packages:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
     engines: {node: '>= 0.4'}
 
+  is-boolean-object@1.2.2:
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
+
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -1225,16 +1739,33 @@ packages:
   is-core-module@2.13.1:
     resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
 
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
+  is-data-view@1.0.2:
+    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
+    engines: {node: '>= 0.4'}
+
   is-date-object@1.0.5:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
+    engines: {node: '>= 0.4'}
+
+  is-document.all@1.0.0:
+    resolution: {integrity: sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==}
     engines: {node: '>= 0.4'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
-  is-finalizationregistry@1.0.2:
-    resolution: {integrity: sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==}
+  is-finalizationregistry@1.1.1:
+    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
+    engines: {node: '>= 0.4'}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -1248,55 +1779,87 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
-  is-map@2.0.2:
-    resolution: {integrity: sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==}
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
 
   is-negative-zero@2.0.2:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
+    engines: {node: '>= 0.4'}
+
+  is-negative-zero@2.0.3:
+    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
 
   is-number-object@1.0.7:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
     engines: {node: '>= 0.4'}
 
+  is-number-object@1.1.1:
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
+    engines: {node: '>= 0.4'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-
-  is-path-inside@3.0.3:
-    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
-    engines: {node: '>=8'}
 
   is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
 
-  is-set@2.0.2:
-    resolution: {integrity: sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==}
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
 
   is-shared-array-buffer@1.0.2:
     resolution: {integrity: sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==}
 
+  is-shared-array-buffer@1.0.4:
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
+
   is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
+    engines: {node: '>= 0.4'}
+
+  is-string@1.1.1:
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
     engines: {node: '>= 0.4'}
 
   is-symbol@1.0.4:
     resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
     engines: {node: '>= 0.4'}
 
+  is-symbol@1.1.1:
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
+
   is-typed-array@1.1.13:
     resolution: {integrity: sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==}
     engines: {node: '>= 0.4'}
 
-  is-weakmap@2.0.1:
-    resolution: {integrity: sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==}
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
 
   is-weakref@1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
 
-  is-weakset@2.0.2:
-    resolution: {integrity: sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==}
+  is-weakref@1.1.1:
+    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
+    engines: {node: '>= 0.4'}
+
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
+    engines: {node: '>= 0.4'}
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -1304,8 +1867,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  iterator.prototype@1.1.2:
-    resolution: {integrity: sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==}
+  iterator.prototype@1.1.5:
+    resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
+    engines: {node: '>= 0.4'}
 
   jackspeak@2.3.6:
     resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
@@ -1318,8 +1882,13 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -1333,6 +1902,11 @@ packages:
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
     hasBin: true
 
   jsx-ast-utils@3.3.5:
@@ -1379,14 +1953,17 @@ packages:
     resolution: {integrity: sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==}
     engines: {node: 14 || >=16.14}
 
-  lru-cache@6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   lucide-react@0.321.0:
     resolution: {integrity: sha512-Fi9VahIna6642U+2nAGSjnXwUBV3WyfFFPQq4yi3w30jtqxDLfSyiYCtCYCYQZ2KWNZc1MDI+rcsa0t+ChdYpw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1396,8 +1973,12 @@ packages:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
     engines: {node: '>=8.6'}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimatch@9.0.3:
     resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
@@ -1409,6 +1990,12 @@ packages:
   minipass@7.0.4:
     resolution: {integrity: sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  motion-dom@12.42.2:
+    resolution: {integrity: sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==}
+
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
 
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -1434,26 +2021,33 @@ packages:
       react: '*'
       react-dom: '*'
 
-  next@14.2.35:
-    resolution: {integrity: sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==}
-    engines: {node: '>=18.17.0'}
+  next@16.2.10:
+    resolution: {integrity: sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==}
+    engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
-      '@playwright/test': ^1.41.2
-      react: ^18.2.0
-      react-dom: ^18.2.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
       sass: ^1.3.0
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
       '@playwright/test':
         optional: true
+      babel-plugin-react-compiler:
+        optional: true
       sass:
         optional: true
 
   node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
+
+  node-releases@2.0.51:
+    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
+    engines: {node: '>=18'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -1474,6 +2068,10 @@ packages:
   object-inspect@1.13.1:
     resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
@@ -1482,30 +2080,37 @@ packages:
     resolution: {integrity: sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==}
     engines: {node: '>= 0.4'}
 
-  object.entries@1.1.7:
-    resolution: {integrity: sha512-jCBs/0plmPsOnrKAfFQXRG2NFjlhZgjjcBLSmTnEhU8U6vVTsVe8ANeQJCHTl3gSsI4J+0emOoCgoKlmQPMgmA==}
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
 
-  object.fromentries@2.0.7:
-    resolution: {integrity: sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==}
+  object.entries@1.1.9:
+    resolution: {integrity: sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==}
     engines: {node: '>= 0.4'}
 
-  object.groupby@1.0.1:
-    resolution: {integrity: sha512-HqaQtqLnp/8Bn4GL16cj+CUYbnpe1bh0TtEaWvybszDG4tgxCJuRpV8VGuvNaI1fAnI4lUJzDG55MXcOH4JZcQ==}
+  object.fromentries@2.0.8:
+    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
+    engines: {node: '>= 0.4'}
 
-  object.hasown@1.1.3:
-    resolution: {integrity: sha512-fFI4VcYpRHvSLXxP7yiZOMAd331cPfd2p7PFDVbgUsYOfCT3tICVqXWngbjr4m49OvsBwUBQ6O2uQoJvy3RexA==}
+  object.groupby@1.0.3:
+    resolution: {integrity: sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==}
+    engines: {node: '>= 0.4'}
 
   object.values@1.1.7:
     resolution: {integrity: sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==}
     engines: {node: '>= 0.4'}
 
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+  object.values@1.2.1:
+    resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
+    engines: {node: '>= 0.4'}
 
   optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
+
+  own-keys@1.0.1:
+    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
+    engines: {node: '>= 0.4'}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -1523,10 +2128,6 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
-
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -1538,16 +2139,19 @@ packages:
     resolution: {integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  path-type@4.0.0:
-    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
-    engines: {node: '>=8'}
-
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -1556,6 +2160,10 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -1616,10 +2224,10 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  react-dom@18.2.0:
-    resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
-      react: ^18.2.0
+      react: ^19.2.7
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -1654,8 +2262,8 @@ packages:
       '@types/react':
         optional: true
 
-  react@18.2.0:
-    resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
   read-cache@1.0.0:
@@ -1665,8 +2273,8 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
-  reflect.getprototypeof@1.0.4:
-    resolution: {integrity: sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==}
+  reflect.getprototypeof@1.0.10:
+    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
 
   regenerator-runtime@0.14.1:
@@ -1674,6 +2282,10 @@ packages:
 
   regexp.prototype.flags@1.5.1:
     resolution: {integrity: sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==}
+    engines: {node: '>= 0.4'}
+
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
   resolve-from@4.0.0:
@@ -1695,11 +2307,6 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1707,19 +2314,31 @@ packages:
     resolution: {integrity: sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==}
     engines: {node: '>=0.4'}
 
+  safe-array-concat@1.1.4:
+    resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
+    engines: {node: '>=0.4'}
+
+  safe-push-apply@1.0.0:
+    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
+    engines: {node: '>= 0.4'}
+
   safe-regex-test@1.0.2:
     resolution: {integrity: sha512-83S9w6eFq12BBIJYvjMux6/dkirb8+4zJRA9cxNBVb7Wq5fJBW+Xze48WqR8pxua7bDuAaaAxtVVd4Idjp1dBQ==}
     engines: {node: '>= 0.4'}
 
-  scheduler@0.23.0:
-    resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.5.4:
-    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -1727,9 +2346,25 @@ packages:
     resolution: {integrity: sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==}
     engines: {node: '>= 0.4'}
 
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
   set-function-name@2.0.1:
     resolution: {integrity: sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==}
     engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+
+  set-proto@1.0.0:
+    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
+    engines: {node: '>= 0.4'}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1739,24 +2374,36 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
   side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  slash@3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
-    engines: {node: '>=8'}
-
   source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
 
-  streamsearch@1.1.0:
-    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
-    engines: {node: '>=10.0.0'}
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -1766,11 +2413,27 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
-  string.prototype.matchall@4.0.10:
-    resolution: {integrity: sha512-rGXbGmOEosIQi6Qva94HUjgPs9vKW+dkG7Y8Q5O2OYkWL6wFaTRZO8zM4mhP94uX55wgyrXzfS2aGtGzUL7EJQ==}
+  string.prototype.includes@2.0.1:
+    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.matchall@4.0.12:
+    resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.repeat@1.0.0:
+    resolution: {integrity: sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==}
+
+  string.prototype.trim@1.2.11:
+    resolution: {integrity: sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==}
+    engines: {node: '>= 0.4'}
 
   string.prototype.trim@1.2.8:
     resolution: {integrity: sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimend@1.0.10:
+    resolution: {integrity: sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==}
     engines: {node: '>= 0.4'}
 
   string.prototype.trimend@1.0.7:
@@ -1778,6 +2441,10 @@ packages:
 
   string.prototype.trimstart@1.0.7:
     resolution: {integrity: sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==}
+
+  string.prototype.trimstart@1.0.8:
+    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
+    engines: {node: '>= 0.4'}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1795,13 +2462,13 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  styled-jsx@5.1.1:
-    resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
       '@babel/core': '*'
       babel-plugin-macros: '*'
-      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -1838,9 +2505,6 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
 
-  text-table@0.2.0:
-    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
-
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -1848,15 +2512,19 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  ts-api-utils@1.0.3:
-    resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
-    engines: {node: '>=16.13.0'}
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
     peerDependencies:
-      typescript: '>=4.2.0'
+      typescript: '>=4.8.4'
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -1867,28 +2535,50 @@ packages:
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  type-fest@0.20.2:
-    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
-    engines: {node: '>=10'}
-
   typed-array-buffer@1.0.0:
     resolution: {integrity: sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
 
   typed-array-byte-length@1.0.0:
     resolution: {integrity: sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==}
     engines: {node: '>= 0.4'}
 
+  typed-array-byte-length@1.0.3:
+    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
+    engines: {node: '>= 0.4'}
+
   typed-array-byte-offset@1.0.0:
     resolution: {integrity: sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==}
     engines: {node: '>= 0.4'}
 
+  typed-array-byte-offset@1.0.4:
+    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
+    engines: {node: '>= 0.4'}
+
   typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
+
+  typed-array-length@1.0.8:
+    resolution: {integrity: sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==}
+    engines: {node: '>= 0.4'}
+
+  typescript-eslint@8.64.0:
+    resolution: {integrity: sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@5.3.3:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
@@ -1898,11 +2588,21 @@ packages:
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
+  unbox-primitive@1.1.0:
+    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
+    engines: {node: '>= 0.4'}
+
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   update-browserslist-db@1.0.13:
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -1936,15 +2636,24 @@ packages:
   which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
 
-  which-builtin-type@1.1.3:
-    resolution: {integrity: sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==}
+  which-boxed-primitive@1.1.1:
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
 
-  which-collection@1.0.1:
-    resolution: {integrity: sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==}
+  which-builtin-type@1.2.1:
+    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
 
   which-typed-array@1.1.14:
     resolution: {integrity: sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==}
+    engines: {node: '>= 0.4'}
+
+  which-typed-array@1.1.22:
+    resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
     engines: {node: '>= 0.4'}
 
   which@2.0.2:
@@ -1960,11 +2669,8 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yaml@2.3.4:
     resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}
@@ -1974,15 +2680,129 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod-validation-error@4.0.2:
+    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.6
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/runtime@7.23.9':
     dependencies:
       regenerator-runtime: 0.14.1
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.6.2
+    optional: true
 
   '@emotion/is-prop-valid@0.8.8':
     dependencies:
@@ -1992,28 +2812,51 @@ snapshots:
   '@emotion/memoize@0.7.4':
     optional: true
 
-  '@eslint-community/eslint-utils@4.4.0(eslint@8.56.0)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.5(jiti@1.21.0))':
     dependencies:
-      eslint: 8.56.0
+      eslint: 9.39.5(jiti@1.21.0)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/regexpp@4.10.0': {}
+  '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/eslintrc@2.1.4':
+  '@eslint/config-array@0.21.2':
     dependencies:
-      ajv: 6.12.6
+      '@eslint/object-schema': 2.1.7
       debug: 4.3.4
-      espree: 9.6.1
-      globals: 13.24.0
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.6':
+    dependencies:
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
       ignore: 5.3.1
       import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
+      js-yaml: 4.3.0
+      minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@8.56.0': {}
+  '@eslint/js@9.39.5': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
 
   '@floating-ui/core@1.6.0':
     dependencies:
@@ -2024,25 +2867,126 @@ snapshots:
       '@floating-ui/core': 1.6.0
       '@floating-ui/utils': 0.2.1
 
-  '@floating-ui/react-dom@2.0.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@floating-ui/react-dom@2.0.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@floating-ui/dom': 1.6.1
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@floating-ui/utils@0.2.1': {}
 
-  '@humanwhocodes/config-array@0.11.14':
+  '@humanfs/core@0.19.2':
     dependencies:
-      '@humanwhocodes/object-schema': 2.0.2
-      debug: 4.3.4
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
 
   '@humanwhocodes/module-importer@1.0.1': {}
 
-  '@humanwhocodes/object-schema@2.0.2': {}
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.2
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -2053,11 +2997,21 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/gen-mapping@0.3.3':
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.22
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.1': {}
 
@@ -2065,42 +3019,46 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.4.15': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@jridgewell/trace-mapping@0.3.22':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@next/env@14.2.35': {}
-
-  '@next/eslint-plugin-next@14.1.0':
+  '@jridgewell/trace-mapping@0.3.31':
     dependencies:
-      glob: 10.3.10
+      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@next/swc-darwin-arm64@14.2.33':
+  '@next/env@16.2.10': {}
+
+  '@next/eslint-plugin-next@16.2.10':
+    dependencies:
+      fast-glob: 3.3.1
+
+  '@next/swc-darwin-arm64@16.2.10':
     optional: true
 
-  '@next/swc-darwin-x64@14.2.33':
+  '@next/swc-darwin-x64@16.2.10':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@14.2.33':
+  '@next/swc-linux-arm64-gnu@16.2.10':
     optional: true
 
-  '@next/swc-linux-arm64-musl@14.2.33':
+  '@next/swc-linux-arm64-musl@16.2.10':
     optional: true
 
-  '@next/swc-linux-x64-gnu@14.2.33':
+  '@next/swc-linux-x64-gnu@16.2.10':
     optional: true
 
-  '@next/swc-linux-x64-musl@14.2.33':
+  '@next/swc-linux-x64-musl@16.2.10':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@14.2.33':
+  '@next/swc-win32-arm64-msvc@16.2.10':
     optional: true
 
-  '@next/swc-win32-ia32-msvc@14.2.33':
-    optional: true
-
-  '@next/swc-win32-x64-msvc@14.2.33':
+  '@next/swc-win32-x64-msvc@16.2.10':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -2122,312 +3080,313 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.23.9
 
-  '@radix-ui/react-arrow@1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-arrow@1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-collection@1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-collection@1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.52)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.0.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-compose-refs@1.0.1(@types/react@18.2.52)(react@18.2.0)':
+  '@radix-ui/react-compose-refs@1.0.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      react: 18.2.0
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
-  '@radix-ui/react-context@1.0.1(@types/react@18.2.52)(react@18.2.0)':
+  '@radix-ui/react-context@1.0.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      react: 18.2.0
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
-  '@radix-ui/react-direction@1.0.1(@types/react@18.2.52)(react@18.2.0)':
+  '@radix-ui/react-direction@1.0.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      react: 18.2.0
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
-  '@radix-ui/react-dismissable-layer@1.0.5(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-dismissable-layer@1.0.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@18.2.52)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-dropdown-menu@2.0.6(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-dropdown-menu@2.0.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-id': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-menu': 2.0.6(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-menu': 2.0.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-focus-guards@1.0.1(@types/react@18.2.52)(react@18.2.0)':
+  '@radix-ui/react-focus-guards@1.0.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      react: 18.2.0
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
-  '@radix-ui/react-focus-scope@1.0.4(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-focus-scope@1.0.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-icons@1.3.0(react@18.2.0)':
+  '@radix-ui/react-icons@1.3.0(react@19.2.7)':
     dependencies:
-      react: 18.2.0
+      react: 19.2.7
 
-  '@radix-ui/react-id@1.0.1(@types/react@18.2.52)(react@18.2.0)':
+  '@radix-ui/react-id@1.0.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      react: 18.2.0
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
-  '@radix-ui/react-menu@2.0.6(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-menu@2.0.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-focus-scope': 1.0.4(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-id': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-popper': 1.1.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-portal': 1.0.4(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.52)(react@18.2.0)
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.0.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.0.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.0.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.0.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.2.17)(react@19.2.7)
       aria-hidden: 1.2.3
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-remove-scroll: 2.5.5(@types/react@18.2.52)(react@18.2.0)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.5.5(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-navigation-menu@1.1.4(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-navigation-menu@1.1.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-id': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-use-previous': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-visually-hidden': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-previous': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-popper@1.1.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-popper@1.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@floating-ui/react-dom': 2.0.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-arrow': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-use-rect': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-use-size': 1.0.1(@types/react@18.2.52)(react@18.2.0)
+      '@floating-ui/react-dom': 2.0.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-arrow': 1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-rect': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.0.1(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/rect': 1.0.1
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-portal@1.0.4(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-portal@1.0.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-presence@1.0.1(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-presence@1.0.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-primitive@1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-primitive@1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.52)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-roving-focus@1.0.4(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-roving-focus@1.0.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-id': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-slot@1.0.2(@types/react@18.2.52)(react@18.2.0)':
+  '@radix-ui/react-slot@1.0.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      react: 18.2.0
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
-  '@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.2.52)(react@18.2.0)':
+  '@radix-ui/react-use-callback-ref@1.0.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      react: 18.2.0
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
-  '@radix-ui/react-use-controllable-state@1.0.1(@types/react@18.2.52)(react@18.2.0)':
+  '@radix-ui/react-use-controllable-state@1.0.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      react: 18.2.0
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
-  '@radix-ui/react-use-escape-keydown@1.0.3(@types/react@18.2.52)(react@18.2.0)':
+  '@radix-ui/react-use-escape-keydown@1.0.3(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      react: 18.2.0
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
-  '@radix-ui/react-use-layout-effect@1.0.1(@types/react@18.2.52)(react@18.2.0)':
+  '@radix-ui/react-use-layout-effect@1.0.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      react: 18.2.0
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
-  '@radix-ui/react-use-previous@1.0.1(@types/react@18.2.52)(react@18.2.0)':
+  '@radix-ui/react-use-previous@1.0.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      react: 18.2.0
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
-  '@radix-ui/react-use-rect@1.0.1(@types/react@18.2.52)(react@18.2.0)':
+  '@radix-ui/react-use-rect@1.0.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/rect': 1.0.1
-      react: 18.2.0
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
-  '@radix-ui/react-use-size@1.0.1(@types/react@18.2.52)(react@18.2.0)':
+  '@radix-ui/react-use-size@1.0.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.52)(react@18.2.0)
-      react: 18.2.0
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
-  '@radix-ui/react-visually-hidden@1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@radix-ui/react-visually-hidden@1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.23.9
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.52)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.2.52
-      '@types/react-dom': 18.2.18
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/rect@1.0.1':
     dependencies:
       '@babel/runtime': 7.23.9
 
-  '@rushstack/eslint-patch@1.7.2': {}
+  '@rtsao/scc@1.1.0': {}
 
-  '@swc/counter@0.1.3': {}
-
-  '@swc/helpers@0.5.5':
+  '@swc/helpers@0.5.15':
     dependencies:
-      '@swc/counter': 0.1.3
-      tslib: 2.6.2
+      tslib: 2.8.1
+
+  '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
 
@@ -2435,61 +3394,104 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/prop-types@15.7.11': {}
-
-  '@types/react-dom@18.2.18':
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
-  '@types/react@18.2.52':
+  '@types/react@19.2.17':
     dependencies:
-      '@types/prop-types': 15.7.11
-      '@types/scheduler': 0.16.8
-      csstype: 3.1.3
+      csstype: 3.2.3
 
-  '@types/scheduler@0.16.8': {}
-
-  '@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.3.3)':
+  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 6.20.0
-      '@typescript-eslint/types': 6.20.0
-      '@typescript-eslint/typescript-estree': 6.20.0(typescript@5.3.3)
-      '@typescript-eslint/visitor-keys': 6.20.0
-      debug: 4.3.4
-      eslint: 8.56.0
-    optionalDependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)
+      '@typescript-eslint/scope-manager': 8.64.0
+      '@typescript-eslint/type-utils': 8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 8.64.0
+      eslint: 9.39.5(jiti@1.21.0)
+      ignore: 7.0.6
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.3.3)
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@6.20.0':
+  '@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)':
     dependencies:
-      '@typescript-eslint/types': 6.20.0
-      '@typescript-eslint/visitor-keys': 6.20.0
-
-  '@typescript-eslint/types@6.20.0': {}
-
-  '@typescript-eslint/typescript-estree@6.20.0(typescript@5.3.3)':
-    dependencies:
-      '@typescript-eslint/types': 6.20.0
-      '@typescript-eslint/visitor-keys': 6.20.0
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      minimatch: 9.0.3
-      semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.3.3)
-    optionalDependencies:
+      '@typescript-eslint/scope-manager': 8.64.0
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 8.64.0
+      debug: 4.4.3
+      eslint: 9.39.5(jiti@1.21.0)
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@6.20.0':
+  '@typescript-eslint/project-service@8.64.0(typescript@5.3.3)':
     dependencies:
-      '@typescript-eslint/types': 6.20.0
-      eslint-visitor-keys: 3.4.3
+      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.3.3)
+      '@typescript-eslint/types': 8.64.0
+      debug: 4.4.3
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
 
-  '@ungap/structured-clone@1.2.0': {}
+  '@typescript-eslint/scope-manager@8.64.0':
+    dependencies:
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/visitor-keys': 8.64.0
+
+  '@typescript-eslint/tsconfig-utils@8.64.0(typescript@5.3.3)':
+    dependencies:
+      typescript: 5.3.3
+
+  '@typescript-eslint/type-utils@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.3.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)
+      debug: 4.4.3
+      eslint: 9.39.5(jiti@1.21.0)
+      ts-api-utils: 2.5.0(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.64.0': {}
+
+  '@typescript-eslint/typescript-estree@8.64.0(typescript@5.3.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.64.0(typescript@5.3.3)
+      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.3.3)
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/visitor-keys': 8.64.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@1.21.0))
+      '@typescript-eslint/scope-manager': 8.64.0
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.3.3)
+      eslint: 9.39.5(jiti@1.21.0)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.64.0':
+    dependencies:
+      '@typescript-eslint/types': 8.64.0
+      eslint-visitor-keys: 5.0.1
 
   '@upstash/core-analytics@0.0.10':
     dependencies:
@@ -2504,13 +3506,13 @@ snapshots:
     dependencies:
       crypto-js: 4.2.0
 
-  acorn-jsx@5.3.2(acorn@8.11.3):
+  acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
-      acorn: 8.11.3
+      acorn: 8.17.0
 
-  acorn@8.11.3: {}
+  acorn@8.17.0: {}
 
-  ajv@6.12.6:
+  ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -2542,14 +3544,17 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
-  aria-query@5.3.0:
-    dependencies:
-      dequal: 2.0.3
+  aria-query@5.3.2: {}
 
   array-buffer-byte-length@1.0.0:
     dependencies:
       call-bind: 1.0.5
       is-array-buffer: 3.0.4
+
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
 
   array-includes@3.1.7:
     dependencies:
@@ -2559,21 +3564,48 @@ snapshots:
       get-intrinsic: 1.2.2
       is-string: 1.0.7
 
-  array-union@2.1.0: {}
-
-  array.prototype.findlastindex@1.2.3:
+  array-includes@3.1.9:
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.9
+      call-bound: 1.0.4
       define-properties: 1.2.1
-      es-abstract: 1.22.3
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.2
+      get-intrinsic: 1.3.0
+      is-string: 1.1.1
+      math-intrinsics: 1.1.0
+
+  array.prototype.findlast@1.2.5:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
       es-shim-unscopables: 1.0.2
-      get-intrinsic: 1.2.2
+
+  array.prototype.findlastindex@1.2.6:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      es-shim-unscopables: 1.1.0
 
   array.prototype.flat@1.3.2:
     dependencies:
       call-bind: 1.0.5
       define-properties: 1.2.1
       es-abstract: 1.22.3
+      es-shim-unscopables: 1.0.2
+
+  array.prototype.flat@1.3.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
       es-shim-unscopables: 1.0.2
 
   array.prototype.flatmap@1.3.2:
@@ -2583,13 +3615,20 @@ snapshots:
       es-abstract: 1.22.3
       es-shim-unscopables: 1.0.2
 
-  array.prototype.tosorted@1.1.2:
+  array.prototype.flatmap@1.3.3:
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.22.3
+      es-abstract: 1.24.2
       es-shim-unscopables: 1.0.2
-      get-intrinsic: 1.2.2
+
+  array.prototype.tosorted@1.1.4:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-shim-unscopables: 1.0.2
 
   arraybuffer.prototype.slice@1.0.2:
     dependencies:
@@ -2601,11 +3640,17 @@ snapshots:
       is-array-buffer: 3.0.4
       is-shared-array-buffer: 1.0.2
 
-  ast-types-flow@0.0.8: {}
-
-  asynciterator.prototype@1.0.0:
+  arraybuffer.prototype.slice@1.0.4:
     dependencies:
-      has-symbols: 1.0.3
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      is-array-buffer: 3.0.4
+
+  ast-types-flow@0.0.8: {}
 
   autoprefixer@10.4.17(postcss@8.4.33):
     dependencies:
@@ -2619,13 +3664,19 @@ snapshots:
 
   available-typed-arrays@1.0.6: {}
 
-  axe-core@4.7.0: {}
-
-  axobject-query@3.2.1:
+  available-typed-arrays@1.0.7:
     dependencies:
-      dequal: 2.0.3
+      possible-typed-array-names: 1.1.0
+
+  axe-core@4.12.1: {}
+
+  axobject-query@4.1.0: {}
 
   balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  baseline-browser-mapping@2.10.43: {}
 
   binary-extensions@2.2.0: {}
 
@@ -2638,6 +3689,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
+  brace-expansion@5.0.7:
+    dependencies:
+      balanced-match: 4.0.4
+
   braces@3.0.2:
     dependencies:
       fill-range: 7.0.1
@@ -2649,9 +3704,18 @@ snapshots:
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.22.3)
 
-  busboy@1.6.0:
+  browserslist@4.28.6:
     dependencies:
-      streamsearch: 1.1.0
+      baseline-browser-mapping: 2.10.43
+      caniuse-lite: 1.0.30001805
+      electron-to-chromium: 1.5.389
+      node-releases: 2.0.51
+      update-browserslist-db: 1.2.3(browserslist@4.28.6)
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   call-bind@1.0.5:
     dependencies:
@@ -2659,11 +3723,25 @@ snapshots:
       get-intrinsic: 1.2.2
       set-function-length: 1.2.0
 
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   callsites@3.1.0: {}
 
   camelcase-css@2.0.1: {}
 
   caniuse-lite@1.0.30001583: {}
+
+  caniuse-lite@1.0.30001805: {}
 
   chalk@4.1.2:
     dependencies:
@@ -2702,7 +3780,15 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  convert-source-map@2.0.0: {}
+
   cross-spawn@7.0.3:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
@@ -2712,9 +3798,27 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  csstype@3.1.3: {}
+  csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-view-buffer@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-offset@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
 
   debug@3.2.7:
     dependencies:
@@ -2724,6 +3828,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.1:
@@ -2732,21 +3840,24 @@ snapshots:
       gopd: 1.0.1
       has-property-descriptors: 1.0.1
 
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.0.1
+
   define-properties@1.2.1:
     dependencies:
       define-data-property: 1.1.1
       has-property-descriptors: 1.0.1
       object-keys: 1.1.1
 
-  dequal@2.0.3: {}
+  detect-libc@2.1.2:
+    optional: true
 
   detect-node-es@1.1.0: {}
 
   didyoumean@1.2.2: {}
-
-  dir-glob@3.0.1:
-    dependencies:
-      path-type: 4.0.0
 
   dlv@1.1.3: {}
 
@@ -2754,13 +3865,17 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  doctrine@3.0.0:
+  dunder-proto@1.0.1:
     dependencies:
-      esutils: 2.0.3
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
 
   electron-to-chromium@1.4.656: {}
+
+  electron-to-chromium@1.5.389: {}
 
   emoji-regex@8.0.0: {}
 
@@ -2770,6 +3885,13 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
+
+  es-abstract-get@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      is-callable: 1.2.7
+      object-inspect: 1.13.4
 
   es-abstract@1.22.3:
     dependencies:
@@ -2813,22 +3935,89 @@ snapshots:
       unbox-primitive: 1.0.2
       which-typed-array: 1.1.14
 
-  es-iterator-helpers@1.0.15:
+  es-abstract@1.24.2:
     dependencies:
-      asynciterator.prototype: 1.0.0
-      call-bind: 1.0.5
+      array-buffer-byte-length: 1.0.2
+      arraybuffer.prototype.slice: 1.0.4
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      data-view-buffer: 1.0.2
+      data-view-byte-length: 1.0.2
+      data-view-byte-offset: 1.0.1
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      es-set-tostringtag: 2.1.0
+      es-to-primitive: 1.3.4
+      function.prototype.name: 1.2.0
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      get-symbol-description: 1.1.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      internal-slot: 1.1.0
+      is-array-buffer: 3.0.5
+      is-callable: 1.2.7
+      is-data-view: 1.0.2
+      is-negative-zero: 2.0.3
+      is-regex: 1.2.1
+      is-set: 2.0.3
+      is-shared-array-buffer: 1.0.4
+      is-string: 1.1.1
+      is-typed-array: 1.1.15
+      is-weakref: 1.1.1
+      math-intrinsics: 1.1.0
+      object-inspect: 1.13.4
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      own-keys: 1.0.1
+      regexp.prototype.flags: 1.5.4
+      safe-array-concat: 1.1.4
+      safe-push-apply: 1.0.0
+      safe-regex-test: 1.1.0
+      set-proto: 1.0.0
+      stop-iteration-iterator: 1.1.0
+      string.prototype.trim: 1.2.11
+      string.prototype.trimend: 1.0.10
+      string.prototype.trimstart: 1.0.8
+      typed-array-buffer: 1.0.3
+      typed-array-byte-length: 1.0.3
+      typed-array-byte-offset: 1.0.4
+      typed-array-length: 1.0.8
+      unbox-primitive: 1.1.0
+      which-typed-array: 1.1.22
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-iterator-helpers@1.4.0:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
       define-properties: 1.2.1
-      es-abstract: 1.22.3
-      es-set-tostringtag: 2.0.2
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-set-tostringtag: 2.1.0
       function-bind: 1.1.2
-      get-intrinsic: 1.2.2
-      globalthis: 1.0.3
-      has-property-descriptors: 1.0.1
-      has-proto: 1.0.1
-      has-symbols: 1.0.3
-      internal-slot: 1.0.6
-      iterator.prototype: 1.1.2
-      safe-array-concat: 1.1.0
+      get-intrinsic: 1.3.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      internal-slot: 1.1.0
+      iterator.prototype: 1.1.5
+      math-intrinsics: 1.1.0
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   es-set-tostringtag@2.0.2:
     dependencies:
@@ -2836,9 +4025,20 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.0
 
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+
   es-shim-unscopables@1.0.2:
     dependencies:
       hasown: 2.0.0
+
+  es-shim-unscopables@1.1.0:
+    dependencies:
+      hasown: 2.0.4
 
   es-to-primitive@1.2.1:
     dependencies:
@@ -2846,25 +4046,37 @@ snapshots:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
 
+  es-to-primitive@1.3.4:
+    dependencies:
+      es-abstract-get: 1.0.0
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      is-callable: 1.2.7
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
+
   escalade@3.1.1: {}
+
+  escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@14.1.0(eslint@8.56.0)(typescript@5.3.3):
+  eslint-config-next@16.2.10(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3):
     dependencies:
-      '@next/eslint-plugin-next': 14.1.0
-      '@rushstack/eslint-patch': 1.7.2
-      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
-      eslint: 8.56.0
+      '@next/eslint-plugin-next': 16.2.10
+      eslint: 9.39.5(jiti@1.21.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
-      eslint-plugin-react: 7.33.2(eslint@8.56.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.5(jiti@1.21.0))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@1.21.0))
+      eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@1.21.0))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@1.21.0))
+      globals: 16.4.0
+      typescript-eslint: 8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)
     optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
+      - '@typescript-eslint/parser'
       - eslint-import-resolver-webpack
       - supports-color
 
@@ -2876,13 +4088,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0)):
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.3
       enhanced-resolve: 5.15.0
-      eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint: 9.39.5(jiti@1.21.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.5(jiti@1.21.0))
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.13.1
@@ -2893,143 +4105,166 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
-      eslint: 8.56.0
+      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)
+      eslint: 9.39.5(jiti@1.21.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0)):
     dependencies:
-      array-includes: 3.1.7
-      array.prototype.findlastindex: 1.2.3
-      array.prototype.flat: 1.3.2
-      array.prototype.flatmap: 1.3.2
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)
+      eslint: 9.39.5(jiti@1.21.0)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.5(jiti@1.21.0)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.56.0
+      eslint: 9.39.5(jiti@1.21.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.20.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      hasown: 2.0.0
-      is-core-module: 2.13.1
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0)))(eslint@9.39.5(jiti@1.21.0))
+      hasown: 2.0.4
+      is-core-module: 2.16.2
       is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.7
-      object.groupby: 1.0.1
-      object.values: 1.1.7
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
       semver: 6.3.1
+      string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 6.20.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.8.0(eslint@8.56.0):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.5(jiti@1.21.0)):
     dependencies:
-      '@babel/runtime': 7.23.9
-      aria-query: 5.3.0
-      array-includes: 3.1.7
+      aria-query: 5.3.2
+      array-includes: 3.1.9
       array.prototype.flatmap: 1.3.2
       ast-types-flow: 0.0.8
-      axe-core: 4.7.0
-      axobject-query: 3.2.1
+      axe-core: 4.12.1
+      axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      es-iterator-helpers: 1.0.15
-      eslint: 8.56.0
-      hasown: 2.0.0
+      eslint: 9.39.5(jiti@1.21.0)
+      hasown: 2.0.4
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
-      minimatch: 3.1.2
-      object.entries: 1.1.7
-      object.fromentries: 2.0.7
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@4.6.0(eslint@8.56.0):
+  eslint-plugin-react-hooks@7.1.1(eslint@9.39.5(jiti@1.21.0)):
     dependencies:
-      eslint: 8.56.0
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.7
+      eslint: 9.39.5(jiti@1.21.0)
+      hermes-parser: 0.25.1
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
-  eslint-plugin-react@7.33.2(eslint@8.56.0):
+  eslint-plugin-react@7.37.5(eslint@9.39.5(jiti@1.21.0)):
     dependencies:
-      array-includes: 3.1.7
-      array.prototype.flatmap: 1.3.2
-      array.prototype.tosorted: 1.1.2
+      array-includes: 3.1.9
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.3
+      array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
-      es-iterator-helpers: 1.0.15
-      eslint: 8.56.0
+      es-iterator-helpers: 1.4.0
+      eslint: 9.39.5(jiti@1.21.0)
       estraverse: 5.3.0
+      hasown: 2.0.4
       jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
-      object.entries: 1.1.7
-      object.fromentries: 2.0.7
-      object.hasown: 1.1.3
-      object.values: 1.1.7
+      minimatch: 3.1.5
+      object.entries: 1.1.9
+      object.fromentries: 2.0.8
+      object.values: 1.2.1
       prop-types: 15.8.1
       resolve: 2.0.0-next.5
       semver: 6.3.1
-      string.prototype.matchall: 4.0.10
+      string.prototype.matchall: 4.0.12
+      string.prototype.repeat: 1.0.0
 
-  eslint-scope@7.2.2:
+  eslint-scope@8.4.0:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint@8.56.0:
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.39.5(jiti@1.21.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
-      '@eslint-community/regexpp': 4.10.0
-      '@eslint/eslintrc': 2.1.4
-      '@eslint/js': 8.56.0
-      '@humanwhocodes/config-array': 0.11.14
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@1.21.0))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.6
+      '@eslint/js': 9.39.5
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
       '@humanwhocodes/module-importer': 1.0.1
-      '@nodelib/fs.walk': 1.2.8
-      '@ungap/structured-clone': 1.2.0
-      ajv: 6.12.6
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
       chalk: 4.1.2
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       debug: 4.3.4
-      doctrine: 3.0.0
       escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.2
-      eslint-visitor-keys: 3.4.3
-      espree: 9.6.1
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
       esquery: 1.5.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
+      file-entry-cache: 8.0.0
       find-up: 5.0.0
       glob-parent: 6.0.2
-      globals: 13.24.0
-      graphemer: 1.4.0
       ignore: 5.3.1
       imurmurhash: 0.1.4
       is-glob: 4.0.3
-      is-path-inside: 3.0.3
-      js-yaml: 4.1.0
       json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.3
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
+    optionalDependencies:
+      jiti: 1.21.0
     transitivePeerDependencies:
       - supports-color
 
-  espree@9.6.1:
+  espree@10.4.0:
     dependencies:
-      acorn: 8.11.3
-      acorn-jsx: 5.3.2(acorn@8.11.3)
-      eslint-visitor-keys: 3.4.3
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 4.2.1
 
   esquery@1.5.0:
     dependencies:
@@ -3044,6 +4279,14 @@ snapshots:
   esutils@2.0.3: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.1:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
 
   fast-glob@3.3.2:
     dependencies:
@@ -3061,9 +4304,13 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
-  file-entry-cache@6.0.1:
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  file-entry-cache@8.0.0:
     dependencies:
-      flat-cache: 3.2.0
+      flat-cache: 4.0.1
 
   fill-range@7.0.1:
     dependencies:
@@ -3074,15 +4321,18 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  flat-cache@3.2.0:
+  flat-cache@4.0.1:
     dependencies:
       flatted: 3.2.9
       keyv: 4.5.4
-      rimraf: 3.0.2
 
   flatted@3.2.9: {}
 
   for-each@0.3.3:
+    dependencies:
+      is-callable: 1.2.7
+
+  for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
 
@@ -3093,15 +4343,15 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
-  framer-motion@11.0.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  framer-motion@12.42.2(@emotion/is-prop-valid@0.8.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
+      motion-dom: 12.42.2
+      motion-utils: 12.39.0
       tslib: 2.6.2
     optionalDependencies:
       '@emotion/is-prop-valid': 0.8.8
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-
-  fs.realpath@1.0.0: {}
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   fsevents@2.3.3:
     optional: true
@@ -3115,11 +4365,25 @@ snapshots:
       es-abstract: 1.22.3
       functions-have-names: 1.2.3
 
+  function.prototype.name@1.2.0:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+      hasown: 2.0.4
+      is-callable: 1.2.7
+      is-document.all: 1.0.0
+
   functions-have-names@1.2.3: {}
 
-  geist@1.2.1(next@14.2.35(react-dom@18.2.0(react@18.2.0))(react@18.2.0)):
+  geist@1.2.1(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
     dependencies:
-      next: 14.2.35(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next: 16.2.10(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
+  gensync@1.0.0-beta.2: {}
 
   get-intrinsic@1.2.2:
     dependencies:
@@ -3128,12 +4392,36 @@ snapshots:
       has-symbols: 1.0.3
       hasown: 2.0.0
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-symbol-description@1.0.0:
     dependencies:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
+
+  get-symbol-description@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
 
   get-tsconfig@4.7.2:
     dependencies:
@@ -3155,39 +4443,26 @@ snapshots:
       minipass: 7.0.4
       path-scurry: 1.10.1
 
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
+  globals@14.0.0: {}
 
-  globals@13.24.0:
-    dependencies:
-      type-fest: 0.20.2
+  globals@16.4.0: {}
 
   globalthis@1.0.3:
     dependencies:
       define-properties: 1.2.1
 
-  globby@11.1.0:
+  globalthis@1.0.4:
     dependencies:
-      array-union: 2.1.0
-      dir-glob: 3.0.1
-      fast-glob: 3.3.2
-      ignore: 5.3.1
-      merge2: 1.4.1
-      slash: 3.0.0
+      define-properties: 1.2.1
+      gopd: 1.0.1
 
   gopd@1.0.1:
     dependencies:
       get-intrinsic: 1.2.2
 
-  graceful-fs@4.2.11: {}
+  gopd@1.2.0: {}
 
-  graphemer@1.4.0: {}
+  graceful-fs@4.2.11: {}
 
   has-bigints@1.0.2: {}
 
@@ -3197,9 +4472,19 @@ snapshots:
     dependencies:
       get-intrinsic: 1.2.2
 
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
   has-proto@1.0.1: {}
 
+  has-proto@1.2.0:
+    dependencies:
+      dunder-proto: 1.0.1
+
   has-symbols@1.0.3: {}
+
+  has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
     dependencies:
@@ -3209,7 +4494,19 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hermes-estree@0.25.1: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
+
   ignore@5.3.1: {}
+
+  ignore@7.0.6: {}
 
   import-fresh@3.3.0:
     dependencies:
@@ -3218,18 +4515,17 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-
-  inherits@2.0.4: {}
-
   internal-slot@1.0.6:
     dependencies:
       get-intrinsic: 1.2.2
       hasown: 2.0.0
       side-channel: 1.0.4
+
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.4
+      side-channel: 1.1.1
 
   invariant@2.2.4:
     dependencies:
@@ -3240,11 +4536,21 @@ snapshots:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
 
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
   is-async-function@2.0.0:
     dependencies:
       has-tostringtag: 1.0.2
 
   is-bigint@1.0.4:
+    dependencies:
+      has-bigints: 1.0.2
+
+  is-bigint@1.1.0:
     dependencies:
       has-bigints: 1.0.2
 
@@ -3257,21 +4563,45 @@ snapshots:
       call-bind: 1.0.5
       has-tostringtag: 1.0.2
 
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-callable@1.2.7: {}
 
   is-core-module@2.13.1:
     dependencies:
       hasown: 2.0.0
 
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
+
+  is-data-view@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      is-typed-array: 1.1.13
+
   is-date-object@1.0.5:
     dependencies:
       has-tostringtag: 1.0.2
 
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-document.all@1.0.0:
+    dependencies:
+      call-bound: 1.0.4
+
   is-extglob@2.1.1: {}
 
-  is-finalizationregistry@1.0.2:
+  is-finalizationregistry@1.1.1:
     dependencies:
-      call-bind: 1.0.5
+      call-bound: 1.0.4
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -3283,63 +4613,99 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
-  is-map@2.0.2: {}
+  is-map@2.0.3: {}
 
   is-negative-zero@2.0.2: {}
+
+  is-negative-zero@2.0.3: {}
 
   is-number-object@1.0.7:
     dependencies:
       has-tostringtag: 1.0.2
 
-  is-number@7.0.0: {}
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
 
-  is-path-inside@3.0.3: {}
+  is-number@7.0.0: {}
 
   is-regex@1.1.4:
     dependencies:
       call-bind: 1.0.5
       has-tostringtag: 1.0.2
 
-  is-set@2.0.2: {}
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+
+  is-set@2.0.3: {}
 
   is-shared-array-buffer@1.0.2:
     dependencies:
       call-bind: 1.0.5
 
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
   is-string@1.0.7:
     dependencies:
+      has-tostringtag: 1.0.2
+
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
   is-symbol@1.0.4:
     dependencies:
       has-symbols: 1.0.3
 
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
+
   is-typed-array@1.1.13:
     dependencies:
       which-typed-array: 1.1.14
 
-  is-weakmap@2.0.1: {}
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.22
+
+  is-weakmap@2.0.2: {}
 
   is-weakref@1.0.2:
     dependencies:
       call-bind: 1.0.5
 
-  is-weakset@2.0.2:
+  is-weakref@1.1.1:
     dependencies:
-      call-bind: 1.0.5
-      get-intrinsic: 1.2.2
+      call-bound: 1.0.4
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
 
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
-  iterator.prototype@1.1.2:
+  iterator.prototype@1.1.5:
     dependencies:
-      define-properties: 1.2.1
-      get-intrinsic: 1.2.2
-      has-symbols: 1.0.3
-      reflect.getprototypeof: 1.0.4
-      set-function-name: 2.0.1
+      define-data-property: 1.1.4
+      es-object-atoms: 1.1.2
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      has-symbols: 1.1.0
+      set-function-name: 2.0.2
 
   jackspeak@2.3.6:
     dependencies:
@@ -3351,9 +4717,11 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
+
+  jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
 
@@ -3364,6 +4732,8 @@ snapshots:
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
+
+  json5@2.2.3: {}
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -3405,13 +4775,15 @@ snapshots:
 
   lru-cache@10.2.0: {}
 
-  lru-cache@6.0.0:
+  lru-cache@5.1.1:
     dependencies:
-      yallist: 4.0.0
+      yallist: 3.1.1
 
-  lucide-react@0.321.0(react@18.2.0):
+  lucide-react@0.321.0(react@19.2.7):
     dependencies:
-      react: 18.2.0
+      react: 19.2.7
+
+  math-intrinsics@1.1.0: {}
 
   merge2@1.4.1: {}
 
@@ -3420,7 +4792,11 @@ snapshots:
       braces: 3.0.2
       picomatch: 2.3.1
 
-  minimatch@3.1.2:
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.7
+
+  minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.11
 
@@ -3431,6 +4807,12 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.0.4: {}
+
+  motion-dom@12.42.2:
+    dependencies:
+      motion-utils: 12.39.0
+
+  motion-utils@12.39.0: {}
 
   ms@2.1.2: {}
 
@@ -3446,38 +4828,39 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next-themes@0.2.1(next@14.2.35(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next-themes@0.2.1(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      next: 14.2.35(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
+      next: 16.2.10(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
-  next@14.2.35(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@next/env': 14.2.35
-      '@swc/helpers': 0.5.5
-      busboy: 1.6.0
+      '@next/env': 16.2.10
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.43
       caniuse-lite: 1.0.30001583
-      graceful-fs: 4.2.11
       postcss: 8.4.31
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(react@18.2.0)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 14.2.33
-      '@next/swc-darwin-x64': 14.2.33
-      '@next/swc-linux-arm64-gnu': 14.2.33
-      '@next/swc-linux-arm64-musl': 14.2.33
-      '@next/swc-linux-x64-gnu': 14.2.33
-      '@next/swc-linux-x64-musl': 14.2.33
-      '@next/swc-win32-arm64-msvc': 14.2.33
-      '@next/swc-win32-ia32-msvc': 14.2.33
-      '@next/swc-win32-x64-msvc': 14.2.33
+      '@next/swc-darwin-arm64': 16.2.10
+      '@next/swc-darwin-x64': 16.2.10
+      '@next/swc-linux-arm64-gnu': 16.2.10
+      '@next/swc-linux-arm64-musl': 16.2.10
+      '@next/swc-linux-x64-gnu': 16.2.10
+      '@next/swc-linux-x64-musl': 16.2.10
+      '@next/swc-win32-arm64-msvc': 16.2.10
+      '@next/swc-win32-x64-msvc': 16.2.10
+      sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
   node-releases@2.0.14: {}
+
+  node-releases@2.0.51: {}
 
   normalize-path@3.0.0: {}
 
@@ -3489,6 +4872,8 @@ snapshots:
 
   object-inspect@1.13.1: {}
 
+  object-inspect@1.13.4: {}
+
   object-keys@1.1.1: {}
 
   object.assign@4.1.5:
@@ -3498,29 +4883,34 @@ snapshots:
       has-symbols: 1.0.3
       object-keys: 1.1.1
 
-  object.entries@1.1.7:
+  object.assign@4.1.7:
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.9
+      call-bound: 1.0.4
       define-properties: 1.2.1
-      es-abstract: 1.22.3
+      es-object-atoms: 1.1.2
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
 
-  object.fromentries@2.0.7:
+  object.entries@1.1.9:
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.9
+      call-bound: 1.0.4
       define-properties: 1.2.1
-      es-abstract: 1.22.3
+      es-object-atoms: 1.1.2
 
-  object.groupby@1.0.1:
+  object.fromentries@2.0.8:
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.22.3
-      get-intrinsic: 1.2.2
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.2
 
-  object.hasown@1.1.3:
+  object.groupby@1.0.3:
     dependencies:
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.22.3
+      es-abstract: 1.24.2
 
   object.values@1.1.7:
     dependencies:
@@ -3528,9 +4918,12 @@ snapshots:
       define-properties: 1.2.1
       es-abstract: 1.22.3
 
-  once@1.4.0:
+  object.values@1.2.1:
     dependencies:
-      wrappy: 1.0.2
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
 
   optionator@0.9.3:
     dependencies:
@@ -3540,6 +4933,12 @@ snapshots:
       levn: 0.4.1
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  own-keys@1.0.1:
+    dependencies:
+      get-intrinsic: 1.3.0
+      object-keys: 1.1.1
+      safe-push-apply: 1.0.0
 
   p-limit@3.1.0:
     dependencies:
@@ -3555,8 +4954,6 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-is-absolute@1.0.1: {}
-
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
@@ -3566,15 +4963,19 @@ snapshots:
       lru-cache: 10.2.0
       minipass: 7.0.4
 
-  path-type@4.0.0: {}
-
   picocolors@1.0.0: {}
 
+  picocolors@1.1.1: {}
+
   picomatch@2.3.1: {}
+
+  picomatch@4.0.5: {}
 
   pify@2.3.0: {}
 
   pirates@4.0.6: {}
+
+  possible-typed-array-names@1.1.0: {}
 
   postcss-import@15.1.0(postcss@8.4.33):
     dependencies:
@@ -3631,45 +5032,42 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-dom@18.2.0(react@18.2.0):
+  react-dom@19.2.7(react@19.2.7):
     dependencies:
-      loose-envify: 1.4.0
-      react: 18.2.0
-      scheduler: 0.23.0
+      react: 19.2.7
+      scheduler: 0.27.0
 
   react-is@16.13.1: {}
 
-  react-remove-scroll-bar@2.3.4(@types/react@18.2.52)(react@18.2.0):
+  react-remove-scroll-bar@2.3.4(@types/react@19.2.17)(react@19.2.7):
     dependencies:
-      react: 18.2.0
-      react-style-singleton: 2.2.1(@types/react@18.2.52)(react@18.2.0)
+      react: 19.2.7
+      react-style-singleton: 2.2.1(@types/react@19.2.17)(react@19.2.7)
       tslib: 2.6.2
     optionalDependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
-  react-remove-scroll@2.5.5(@types/react@18.2.52)(react@18.2.0):
+  react-remove-scroll@2.5.5(@types/react@19.2.17)(react@19.2.7):
     dependencies:
-      react: 18.2.0
-      react-remove-scroll-bar: 2.3.4(@types/react@18.2.52)(react@18.2.0)
-      react-style-singleton: 2.2.1(@types/react@18.2.52)(react@18.2.0)
+      react: 19.2.7
+      react-remove-scroll-bar: 2.3.4(@types/react@19.2.17)(react@19.2.7)
+      react-style-singleton: 2.2.1(@types/react@19.2.17)(react@19.2.7)
       tslib: 2.6.2
-      use-callback-ref: 1.3.1(@types/react@18.2.52)(react@18.2.0)
-      use-sidecar: 1.1.2(@types/react@18.2.52)(react@18.2.0)
+      use-callback-ref: 1.3.1(@types/react@19.2.17)(react@19.2.7)
+      use-sidecar: 1.1.2(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
-  react-style-singleton@2.2.1(@types/react@18.2.52)(react@18.2.0):
+  react-style-singleton@2.2.1(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       get-nonce: 1.0.1
       invariant: 2.2.4
-      react: 18.2.0
+      react: 19.2.7
       tslib: 2.6.2
     optionalDependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
-  react@18.2.0:
-    dependencies:
-      loose-envify: 1.4.0
+  react@19.2.7: {}
 
   read-cache@1.0.0:
     dependencies:
@@ -3679,14 +5077,16 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
-  reflect.getprototypeof@1.0.4:
+  reflect.getprototypeof@1.0.10:
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.22.3
-      get-intrinsic: 1.2.2
-      globalthis: 1.0.3
-      which-builtin-type: 1.1.3
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      which-builtin-type: 1.2.1
 
   regenerator-runtime@0.14.1: {}
 
@@ -3695,6 +5095,15 @@ snapshots:
       call-bind: 1.0.5
       define-properties: 1.2.1
       set-function-name: 2.0.1
+
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
 
   resolve-from@4.0.0: {}
 
@@ -3714,10 +5123,6 @@ snapshots:
 
   reusify@1.0.4: {}
 
-  rimraf@3.0.2:
-    dependencies:
-      glob: 7.2.3
-
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -3729,21 +5134,36 @@ snapshots:
       has-symbols: 1.0.3
       isarray: 2.0.5
 
+  safe-array-concat@1.1.4:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      isarray: 2.0.5
+
+  safe-push-apply@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      isarray: 2.0.5
+
   safe-regex-test@1.0.2:
     dependencies:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
       is-regex: 1.1.4
 
-  scheduler@0.23.0:
+  safe-regex-test@1.1.0:
     dependencies:
-      loose-envify: 1.4.0
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
+  scheduler@0.27.0: {}
 
   semver@6.3.1: {}
 
-  semver@7.5.4:
-    dependencies:
-      lru-cache: 6.0.0
+  semver@7.8.5: {}
 
   set-function-length@1.2.0:
     dependencies:
@@ -3753,11 +5173,65 @@ snapshots:
       gopd: 1.0.1
       has-property-descriptors: 1.0.1
 
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.2
+
   set-function-name@2.0.1:
     dependencies:
       define-data-property: 1.1.1
       functions-have-names: 1.2.3
       has-property-descriptors: 1.0.1
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+
+  set-proto@1.0.0:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -3765,19 +5239,48 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
   side-channel@1.0.4:
     dependencies:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
       object-inspect: 1.13.1
 
-  signal-exit@4.1.0: {}
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
-  slash@3.0.0: {}
+  signal-exit@4.1.0: {}
 
   source-map-js@1.0.2: {}
 
-  streamsearch@1.1.0: {}
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
 
   string-width@4.2.3:
     dependencies:
@@ -3791,23 +5294,56 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
 
-  string.prototype.matchall@4.0.10:
+  string.prototype.includes@2.0.1:
     dependencies:
-      call-bind: 1.0.5
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+
+  string.prototype.matchall@4.0.12:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      internal-slot: 1.1.0
+      regexp.prototype.flags: 1.5.4
+      set-function-name: 2.0.2
+      side-channel: 1.1.1
+
+  string.prototype.repeat@1.0.0:
+    dependencies:
       define-properties: 1.2.1
       es-abstract: 1.22.3
-      get-intrinsic: 1.2.2
-      has-symbols: 1.0.3
-      internal-slot: 1.0.6
-      regexp.prototype.flags: 1.5.1
-      set-function-name: 2.0.1
-      side-channel: 1.0.4
+
+  string.prototype.trim@1.2.11:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-data-property: 1.1.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.2
+      has-property-descriptors: 1.0.2
+      safe-regex-test: 1.1.0
 
   string.prototype.trim@1.2.8:
     dependencies:
       call-bind: 1.0.5
       define-properties: 1.2.1
       es-abstract: 1.22.3
+
+  string.prototype.trimend@1.0.10:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
 
   string.prototype.trimend@1.0.7:
     dependencies:
@@ -3821,6 +5357,12 @@ snapshots:
       define-properties: 1.2.1
       es-abstract: 1.22.3
 
+  string.prototype.trimstart@1.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -3833,10 +5375,12 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styled-jsx@5.1.1(react@18.2.0):
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
     dependencies:
       client-only: 0.0.1
-      react: 18.2.0
+      react: 19.2.7
+    optionalDependencies:
+      '@babel/core': 7.29.7
 
   sucrase@3.35.0:
     dependencies:
@@ -3891,8 +5435,6 @@ snapshots:
 
   tapable@2.2.1: {}
 
-  text-table@0.2.0: {}
-
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -3901,11 +5443,16 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
-  ts-api-utils@1.0.3(typescript@5.3.3):
+  ts-api-utils@2.5.0(typescript@5.3.3):
     dependencies:
       typescript: 5.3.3
 
@@ -3920,11 +5467,11 @@ snapshots:
 
   tslib@2.6.2: {}
 
+  tslib@2.8.1: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  type-fest@0.20.2: {}
 
   typed-array-buffer@1.0.0:
     dependencies:
@@ -3932,12 +5479,26 @@ snapshots:
       get-intrinsic: 1.2.2
       is-typed-array: 1.1.13
 
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+
   typed-array-byte-length@1.0.0:
     dependencies:
       call-bind: 1.0.5
       for-each: 0.3.3
       has-proto: 1.0.1
       is-typed-array: 1.1.13
+
+  typed-array-byte-length@1.0.3:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.3
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
 
   typed-array-byte-offset@1.0.0:
     dependencies:
@@ -3947,11 +5508,41 @@ snapshots:
       has-proto: 1.0.1
       is-typed-array: 1.1.13
 
+  typed-array-byte-offset@1.0.4:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      for-each: 0.3.3
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+      reflect.getprototypeof: 1.0.10
+
   typed-array-length@1.0.4:
     dependencies:
       call-bind: 1.0.5
       for-each: 0.3.3
       is-typed-array: 1.1.13
+
+  typed-array-length@1.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      is-typed-array: 1.1.15
+      possible-typed-array-names: 1.1.0
+      reflect.getprototypeof: 1.0.10
+
+  typescript-eslint@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3))(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)
+      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.3.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5(jiti@1.21.0))(typescript@5.3.3)
+      eslint: 9.39.5(jiti@1.21.0)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@5.3.3: {}
 
@@ -3962,6 +5553,13 @@ snapshots:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
 
+  unbox-primitive@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-bigints: 1.0.2
+      has-symbols: 1.1.0
+      which-boxed-primitive: 1.1.1
+
   undici-types@5.26.5: {}
 
   update-browserslist-db@1.0.13(browserslist@4.22.3):
@@ -3970,24 +5568,30 @@ snapshots:
       escalade: 3.1.1
       picocolors: 1.0.0
 
+  update-browserslist-db@1.2.3(browserslist@4.28.6):
+    dependencies:
+      browserslist: 4.28.6
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
-  use-callback-ref@1.3.1(@types/react@18.2.52)(react@18.2.0):
+  use-callback-ref@1.3.1(@types/react@19.2.17)(react@19.2.7):
     dependencies:
-      react: 18.2.0
+      react: 19.2.7
       tslib: 2.6.2
     optionalDependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
-  use-sidecar@1.1.2(@types/react@18.2.52)(react@18.2.0):
+  use-sidecar@1.1.2(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       detect-node-es: 1.1.0
-      react: 18.2.0
+      react: 19.2.7
       tslib: 2.6.2
     optionalDependencies:
-      '@types/react': 18.2.52
+      '@types/react': 19.2.17
 
   util-deprecate@1.0.2: {}
 
@@ -3999,27 +5603,36 @@ snapshots:
       is-string: 1.0.7
       is-symbol: 1.0.4
 
-  which-builtin-type@1.1.3:
+  which-boxed-primitive@1.1.1:
     dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-builtin-type@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
       function.prototype.name: 1.1.6
       has-tostringtag: 1.0.2
       is-async-function: 2.0.0
-      is-date-object: 1.0.5
-      is-finalizationregistry: 1.0.2
+      is-date-object: 1.1.0
+      is-finalizationregistry: 1.1.1
       is-generator-function: 1.0.10
-      is-regex: 1.1.4
+      is-regex: 1.2.1
       is-weakref: 1.0.2
       isarray: 2.0.5
-      which-boxed-primitive: 1.0.2
-      which-collection: 1.0.1
-      which-typed-array: 1.1.14
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.22
 
-  which-collection@1.0.1:
+  which-collection@1.0.2:
     dependencies:
-      is-map: 2.0.2
-      is-set: 2.0.2
-      is-weakmap: 2.0.1
-      is-weakset: 2.0.2
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
 
   which-typed-array@1.1.14:
     dependencies:
@@ -4027,6 +5640,16 @@ snapshots:
       call-bind: 1.0.5
       for-each: 0.3.3
       gopd: 1.0.1
+      has-tostringtag: 1.0.2
+
+  which-typed-array@1.1.22:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
       has-tostringtag: 1.0.2
 
   which@2.0.2:
@@ -4045,10 +5668,14 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.0
 
-  wrappy@1.0.2: {}
-
-  yallist@4.0.0: {}
+  yallist@3.1.1: {}
 
   yaml@2.3.4: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-validation-error@4.0.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  sharp: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-allowBuilds:
-  sharp: true

--- a/public/blog/audit.svg
+++ b/public/blog/audit.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" fill="none">
   <rect width="1200" height="630" fill="#0a0a0a"/>
-  <rect x="0" y="0" width="1200" height="630" fill="url(#g)" opacity="0.5"/>
+  <rect width="1200" height="630" fill="url(#g)" opacity="0.5"/>
   <defs>
     <linearGradient id="g" x1="0" y1="0" x2="1200" y2="630">
       <stop stop-color="#222"/><stop offset="1" stop-color="#111"/>
     </linearGradient>
   </defs>
-  <text x="80" y="320" fill="#fafafa" font-family="ui-monospace,monospace" font-size="72" font-weight="700">Site Audit</text>
-  <text x="80" y="390" fill="#a3a3a3" font-family="ui-monospace,monospace" font-size="28">SeoCheckup</text>
+  <text x="600" y="300" text-anchor="middle" fill="#fafafa" font-family="ui-monospace,monospace" font-size="72" font-weight="700">Site Audit</text>
+  <text x="600" y="370" text-anchor="middle" fill="#a3a3a3" font-family="ui-monospace,monospace" font-size="28">SeoCheckup</text>
 </svg>

--- a/public/blog/audit.svg
+++ b/public/blog/audit.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" fill="none">
+  <rect width="1200" height="630" fill="#0a0a0a"/>
+  <rect x="0" y="0" width="1200" height="630" fill="url(#g)" opacity="0.5"/>
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1200" y2="630">
+      <stop stop-color="#222"/><stop offset="1" stop-color="#111"/>
+    </linearGradient>
+  </defs>
+  <text x="80" y="320" fill="#fafafa" font-family="ui-monospace,monospace" font-size="72" font-weight="700">Site Audit</text>
+  <text x="80" y="390" fill="#a3a3a3" font-family="ui-monospace,monospace" font-size="28">SeoCheckup</text>
+</svg>

--- a/public/blog/domain-rating.svg
+++ b/public/blog/domain-rating.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" fill="none">
   <rect width="1200" height="630" fill="#0a0a0a"/>
-  <rect x="0" y="0" width="1200" height="630" fill="url(#g)" opacity="0.5"/>
+  <rect width="1200" height="630" fill="url(#g)" opacity="0.5"/>
   <defs>
     <linearGradient id="g" x1="0" y1="0" x2="1200" y2="630">
       <stop stop-color="#222"/><stop offset="1" stop-color="#111"/>
     </linearGradient>
   </defs>
-  <text x="80" y="320" fill="#fafafa" font-family="ui-monospace,monospace" font-size="72" font-weight="700">Domain Rating</text>
-  <text x="80" y="390" fill="#a3a3a3" font-family="ui-monospace,monospace" font-size="28">SeoCheckup</text>
+  <text x="600" y="300" text-anchor="middle" fill="#fafafa" font-family="ui-monospace,monospace" font-size="72" font-weight="700">Domain Rating</text>
+  <text x="600" y="370" text-anchor="middle" fill="#a3a3a3" font-family="ui-monospace,monospace" font-size="28">SeoCheckup</text>
 </svg>

--- a/public/blog/domain-rating.svg
+++ b/public/blog/domain-rating.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" fill="none">
+  <rect width="1200" height="630" fill="#0a0a0a"/>
+  <rect x="0" y="0" width="1200" height="630" fill="url(#g)" opacity="0.5"/>
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1200" y2="630">
+      <stop stop-color="#222"/><stop offset="1" stop-color="#111"/>
+    </linearGradient>
+  </defs>
+  <text x="80" y="320" fill="#fafafa" font-family="ui-monospace,monospace" font-size="72" font-weight="700">Domain Rating</text>
+  <text x="80" y="390" fill="#a3a3a3" font-family="ui-monospace,monospace" font-size="28">SeoCheckup</text>
+</svg>

--- a/public/blog/metadata.svg
+++ b/public/blog/metadata.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" fill="none">
+  <rect width="1200" height="630" fill="#0a0a0a"/>
+  <rect x="0" y="0" width="1200" height="630" fill="url(#g)" opacity="0.5"/>
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1200" y2="630">
+      <stop stop-color="#222"/><stop offset="1" stop-color="#111"/>
+    </linearGradient>
+  </defs>
+  <text x="80" y="320" fill="#fafafa" font-family="ui-monospace,monospace" font-size="72" font-weight="700">Meta Tags</text>
+  <text x="80" y="390" fill="#a3a3a3" font-family="ui-monospace,monospace" font-size="28">SeoCheckup</text>
+</svg>

--- a/public/blog/metadata.svg
+++ b/public/blog/metadata.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" fill="none">
   <rect width="1200" height="630" fill="#0a0a0a"/>
-  <rect x="0" y="0" width="1200" height="630" fill="url(#g)" opacity="0.5"/>
+  <rect width="1200" height="630" fill="url(#g)" opacity="0.5"/>
   <defs>
     <linearGradient id="g" x1="0" y1="0" x2="1200" y2="630">
       <stop stop-color="#222"/><stop offset="1" stop-color="#111"/>
     </linearGradient>
   </defs>
-  <text x="80" y="320" fill="#fafafa" font-family="ui-monospace,monospace" font-size="72" font-weight="700">Meta Tags</text>
-  <text x="80" y="390" fill="#a3a3a3" font-family="ui-monospace,monospace" font-size="28">SeoCheckup</text>
+  <text x="600" y="300" text-anchor="middle" fill="#fafafa" font-family="ui-monospace,monospace" font-size="72" font-weight="700">Meta Tags</text>
+  <text x="600" y="370" text-anchor="middle" fill="#a3a3a3" font-family="ui-monospace,monospace" font-size="28">SeoCheckup</text>
 </svg>

--- a/public/blog/robots.svg
+++ b/public/blog/robots.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" fill="none">
+  <rect width="1200" height="630" fill="#0a0a0a"/>
+  <rect x="0" y="0" width="1200" height="630" fill="url(#g)" opacity="0.5"/>
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1200" y2="630">
+      <stop stop-color="#222"/><stop offset="1" stop-color="#111"/>
+    </linearGradient>
+  </defs>
+  <text x="80" y="320" fill="#fafafa" font-family="ui-monospace,monospace" font-size="72" font-weight="700">Robots.txt</text>
+  <text x="80" y="390" fill="#a3a3a3" font-family="ui-monospace,monospace" font-size="28">SeoCheckup</text>
+</svg>

--- a/public/blog/robots.svg
+++ b/public/blog/robots.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" fill="none">
   <rect width="1200" height="630" fill="#0a0a0a"/>
-  <rect x="0" y="0" width="1200" height="630" fill="url(#g)" opacity="0.5"/>
+  <rect width="1200" height="630" fill="url(#g)" opacity="0.5"/>
   <defs>
     <linearGradient id="g" x1="0" y1="0" x2="1200" y2="630">
       <stop stop-color="#222"/><stop offset="1" stop-color="#111"/>
     </linearGradient>
   </defs>
-  <text x="80" y="320" fill="#fafafa" font-family="ui-monospace,monospace" font-size="72" font-weight="700">Robots.txt</text>
-  <text x="80" y="390" fill="#a3a3a3" font-family="ui-monospace,monospace" font-size="28">SeoCheckup</text>
+  <text x="600" y="300" text-anchor="middle" fill="#fafafa" font-family="ui-monospace,monospace" font-size="72" font-weight="700">Robots.txt</text>
+  <text x="600" y="370" text-anchor="middle" fill="#a3a3a3" font-family="ui-monospace,monospace" font-size="28">SeoCheckup</text>
 </svg>

--- a/public/blog/sitemap.svg
+++ b/public/blog/sitemap.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" fill="none">
+  <rect width="1200" height="630" fill="#0a0a0a"/>
+  <rect x="0" y="0" width="1200" height="630" fill="url(#g)" opacity="0.5"/>
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1200" y2="630">
+      <stop stop-color="#222"/><stop offset="1" stop-color="#111"/>
+    </linearGradient>
+  </defs>
+  <text x="80" y="320" fill="#fafafa" font-family="ui-monospace,monospace" font-size="72" font-weight="700">XML Sitemap</text>
+  <text x="80" y="390" fill="#a3a3a3" font-family="ui-monospace,monospace" font-size="28">SeoCheckup</text>
+</svg>

--- a/public/blog/sitemap.svg
+++ b/public/blog/sitemap.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" fill="none">
   <rect width="1200" height="630" fill="#0a0a0a"/>
-  <rect x="0" y="0" width="1200" height="630" fill="url(#g)" opacity="0.5"/>
+  <rect width="1200" height="630" fill="url(#g)" opacity="0.5"/>
   <defs>
     <linearGradient id="g" x1="0" y1="0" x2="1200" y2="630">
       <stop stop-color="#222"/><stop offset="1" stop-color="#111"/>
     </linearGradient>
   </defs>
-  <text x="80" y="320" fill="#fafafa" font-family="ui-monospace,monospace" font-size="72" font-weight="700">XML Sitemap</text>
-  <text x="80" y="390" fill="#a3a3a3" font-family="ui-monospace,monospace" font-size="28">SeoCheckup</text>
+  <text x="600" y="300" text-anchor="middle" fill="#fafafa" font-family="ui-monospace,monospace" font-size="72" font-weight="700">XML Sitemap</text>
+  <text x="600" y="370" text-anchor="middle" fill="#a3a3a3" font-family="ui-monospace,monospace" font-size="28">SeoCheckup</text>
 </svg>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,10 +3,8 @@ import type { Config } from "tailwindcss"
 const config = {
   darkMode: ["class"],
   content: [
-    "./pages/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",
     "./app/**/*.{ts,tsx}",
-    "./src/**/*.{ts,tsx}",
   ],
   prefix: "",
   theme: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,6 +5,8 @@ const config = {
   content: [
     "./components/**/*.{ts,tsx}",
     "./app/**/*.{ts,tsx}",
+    "./content/**/*.{md,mdx}",
+    "./mdx-components.tsx",
   ],
   prefix: "",
   theme: {
@@ -85,7 +87,7 @@ const config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [require("tailwindcss-animate"), require("@tailwindcss/typography")],
 } satisfies Config
 
 export default config

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -10,7 +14,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -18,9 +22,20 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
-    }
+      "@/*": [
+        "./*"
+      ]
+    },
+    "target": "ES2017"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
+    "**/*.mdx",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],

--- a/types/mdx.d.ts
+++ b/types/mdx.d.ts
@@ -1,0 +1,5 @@
+declare module "*.mdx" {
+  import type { MDXProps } from "mdx/types"
+  const MDXComponent: (props: MDXProps) => JSX.Element
+  export default MDXComponent
+}


### PR DESCRIPTION
## Summary
- Upgrade to Next.js 16.2 / React 19 with async `searchParams`, ESLint flat config, and green `pnpm build` / `pnpm lint`
- Sitemap index expansion, source filter, Robots tool, SEO landings, Site Audit, Domain Rating, MDX blog
- Harden outbound fetches (SSRF guards, gzip caps, isolated rate limits) and server-side Discord logging

## Environment variables

Copy [`.env.example`](.env.example) locally (`cp .env.example .env.local`).

Add these in **Vercel → Settings → Environment Variables** for **Production** and **Preview**:

| Variable | Required | Used by | Notes |
| --- | --- | --- | --- |
| `UPSTASH_REDIS_REST_URL` | **Yes** | `lib/rate-limit.ts` → `/api/v1`, `/api/sitemap`, `/api/audit`, `/api/domain-rating` | Upstash Redis REST URL |
| `UPSTASH_REDIS_REST_TOKEN` | **Yes** | same | Upstash Redis REST token |
| `DISCORD_LOGS_ID` | Recommended | `lib/discord-webhook.ts` (server only) | Discord webhook ID |
| `DISCORD_LOGS_TOKEN` | Recommended | same | Discord webhook token |

### Not required
- **Ahrefs Domain Rating** — public free API, no key
- `NODE_ENV` — set by Next.js / Vercel

### Discord migration
1. Set `DISCORD_LOGS_ID` + `DISCORD_LOGS_TOKEN` (same values as the old webhook).
2. Optionally keep `NEXT_PUBLIC_DISCORD_LOGS_*` briefly as server fallback.
3. After deploy works, **delete** `NEXT_PUBLIC_DISCORD_*` from Vercel so the token is never client-exposed.
4. Tool logging is skipped when `NODE_ENV=development`. Client `POST /api/logs` is disabled (410); APIs log after success.

### Rate-limit buckets (per IP / 24h)
| Prefix | Route | Limit |
| --- | --- | --- |
| `v1:` | `/api/v1` | 20 |
| `sitemap:` | `/api/sitemap` | 20 |
| `audit:` | `/api/audit` | 15 |
| `dr:` | `/api/domain-rating` | 30 |

## Test plan
- [ ] Set envs from `.env.example` on Vercel Preview + Production
- [ ] `pnpm install && pnpm build && pnpm lint`
- [ ] `/` — audit hero CTA + tool cards
- [ ] `/audit?q=…`, `/domain-rating?q=…`, `/sitemap`, `/metadata`, `/robots`
- [ ] Landings: `/site-audit`, `/domain-rating-checker`, `*-checker`
- [ ] `/blog` + a post; `/sitemap.xml` includes new routes
- [ ] Missing Upstash → rate-limit path fails closed / 429 when configured
- [ ] Discord server envs → production tool use posts webhook (not client)
- [ ] Private IPs / localhost rejected by fetch APIs